### PR TITLE
Feat: HttpMessage 프로토타입 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 
-SRCS	=	$(wildcard ./srcs/*.cpp)
+SRCS	=	$(wildcard ./srcs/*.cpp)\
+			srcs/HttpMessage/HttpMessageRequest.cpp\
+			srcs/HttpMessage/HttpMessageResponse.cpp
+
+
 
 OBJS	=	$(SRCS:.cpp=.o)
 
-NAME	=	Webserv
+NAME	=	webserv
 
 CC		=	clang++
 
-# CFLAG	=	-Wall -Wextra -Werror
+CFLAG	=	-Wall -Wextra -Werror -std=c++98 -g3 -fsanitize=address
 
 RM		=	-rm -rf
 
@@ -24,8 +28,8 @@ re		:	fclean all
 
 $(NAME)	:	$(OBJS)
 # $(CC) -c $(SRCS)
-			$(CC) -o $(NAME) $(OBJS)
-
+			$(CC) $(CFLAG) -o $(NAME) $(OBJS)
+			./webserv
 # $(CC) $(CFLAG) -c $(SRCS)
 # $(CC) $(CFLAG) -o $(NAME) $(OBJS)
 

--- a/srcs/HttpMessage/HttpMessageRequest.cpp
+++ b/srcs/HttpMessage/HttpMessageRequest.cpp
@@ -1,0 +1,142 @@
+#include <iostream>	//	FIXME	나중에 지우기 테스트용
+#include <fstream>	//	FIXME	나중에 지우기 테스트용
+#include <iomanip>	//	FIXME	나중에 지우기 테스트용
+#include "HttpMessageRequest.hpp"
+
+HttpMessageRequest::HttpMessageRequest(char* buf)
+	: mBuffer(buf)
+	, mIsvalid(false)
+	, mCursor(REQUESTLINE)
+{
+}
+
+HttpMessageRequest::~HttpMessageRequest(void)
+{
+}
+
+void		HttpMessageRequest::Test(void)
+{
+	std::cout << std::endl << std::string(10, '-') << "RequestLine" << std::string(10, '-') << std::endl;
+	std::cout << std::setw(20) << "method";
+	std::cout << " |" << mRequestLine.mMethod << "|" << std::endl;
+	std::cout << std::setw(20) << "ReqestTarget";
+	std::cout << " |" << mRequestLine.mRequestTarget << "|" << std::endl;
+	std::cout << std::setw(20) << "httpVersion";
+	std::cout << " |" << mRequestLine.mHttpVersion << "|" << std::endl;
+
+	std::cout << std::endl << std::string(10, '-') << "HeaderField" << std::string(10, '-') << std::endl;
+	for (std::map<std::string, std::string>::iterator it = mHeaderField.begin(); it != mHeaderField.end(); ++it)
+	{
+		std::cout << std::setw(20) << it->first;
+		std::cout << " |" << it->second << "|" << std::endl;
+	}
+
+	if (mMessageBody.empty() == false)
+	{
+		std::cout << std::endl << std::string(10, '-') << "MessageBody" << std::string(10, '-') << std::endl;
+		int i = 0;
+		for (std::deque<char*>::iterator it = mMessageBody.begin(); it != mMessageBody.end(); ++it)
+		{
+			i++;
+			std::cout << std::setw(20) << "#" << i;
+			std::cout << " |" << *it << "|" << std::endl;
+		}
+
+		std::cout << std::endl << std::string(10, '-') << "File   Test" << std::string(10, '-') << std::endl;
+		std::ofstream	ofs("binarytest.png", std::ofstream::out | std::ofstream::trunc);
+
+		ofs.write(*(mMessageBody.begin()), std::atol(mHeaderField["Content-Length"].c_str()));	//	REVIEW : atol 허용함수 인지
+
+		ofs.close();
+	}
+}
+
+static void	eraseCR(char* token)
+{
+	if (token == NULL)
+	{
+		return ;
+	}
+	char*	cr = strrchr(token, '\r');
+	if (cr)
+	{
+		*cr = '\0';
+	}
+}
+
+void	HttpMessageRequest::Parser(void)
+{
+	char* token = NULL;
+	//	RequestLine PARSING
+	if (mCursor == REQUESTLINE)
+	{
+		token = strtok(mBuffer, " ");
+		mRequestLine.mMethod = token;
+		token = strtok(NULL, " ");
+		mRequestLine.mRequestTarget = token;
+		token = strtok(NULL, "\n");
+		eraseCR(token);
+		mRequestLine.mHttpVersion = token;
+		mCursor = HEADERFIELD;
+	}
+	//	HeaderField PARSING
+	if (mCursor == HEADERFIELD)
+	{
+		while (true)
+		{
+			token = strtok(NULL, "\n");
+			char*	colon = strchr(token, ':');
+			if (colon)
+			{
+				*colon = '\0';
+				std::string	name = token;
+				colon++;
+				eraseCR(colon);
+				std::string	value = colon;
+
+				//	OWS trim (앞뒤 공백 자름)
+				std::size_t foundFromFront = value.find_first_not_of(" ");
+				if (foundFromFront == std::string::npos)
+				{
+					foundFromFront = 0;
+				}
+				std::size_t foundFromBack = value.find_last_not_of(" ");
+				//	REVIEW : substr이 leak을 유발할수도 있으니 확인 필요 
+				if (foundFromBack != value.length())
+				{
+					value = value.substr(foundFromFront, foundFromBack - foundFromFront + 1);
+				}
+				else
+				{
+					value = value.substr(foundFromFront, foundFromBack); // string is shorter as many as possible
+				}
+				mHeaderField[name] = value;
+			}
+			else
+			{
+				mCursor = MESSAGEBODY;
+				token += 2;	//	header field 바로 다음 줄의 CR LF 넘기기 //	REVIEW : BUFFER가 딱 맞으면 index 벗어날 수도 있음
+				break ;
+			}
+		}
+	}
+
+	//	MessageBody PARSING
+	if (mCursor == MESSAGEBODY)
+	{
+		if (token == NULL)
+		{
+			mMessageBody.push_back(mBuffer); //	STUB : buffer가 작거나 chunked일 일 경우 고려해서 작성함
+		}
+		else
+		{
+			if (*token)
+			{
+				//	NOTE : message body 없는 경우 '\0'가 들어가면 문제 생길 수 있음
+				mMessageBody.push_back(token);
+				mIsvalid = true;
+			}
+		}
+	}
+	// Test();	//	ANCHOR : 테스트 코드
+}

--- a/srcs/HttpMessage/HttpMessageRequest.hpp
+++ b/srcs/HttpMessage/HttpMessageRequest.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <map>
+#include <queue>
+#include <string>
+
+class HttpMessageRequest
+{
+public:
+    HttpMessageRequest(char* buf);
+    ~HttpMessageRequest(void);
+
+	void	Parser(void);
+
+	void	Test(void);	//	NOTE : test용 코드
+
+private:
+
+	struct RequestLine
+	{
+		std::string	mMethod;
+		std::string	mRequestTarget;
+		std::string	mHttpVersion;
+	};
+	
+	enum eCursor
+	{
+		REQUESTLINE,
+		HEADERFIELD,
+		MESSAGEBODY
+	};
+
+	char*								mBuffer;
+	RequestLine							mRequestLine;
+    std::map<std::string, std::string>	mHeaderField;
+    std::deque<char*>					mMessageBody;	//	NOTE : messagebody 바꾸어야 할수도 있음
+	bool								mIsvalid;		//	FIXME : 어디에서 invalid한지 알아야 적절한 statuscode 날릴 수 있음 수정 필요 Cursor랑 조합..?
+	eCursor								mCursor;
+};

--- a/srcs/HttpMessage/HttpMessageResponse.cpp
+++ b/srcs/HttpMessage/HttpMessageResponse.cpp
@@ -1,0 +1,107 @@
+#include <iostream>	//	FIXME	나중에 지우기 테스트용
+#include <fstream>	//	FIXME	나중에 지우기 테스트용
+#include <iomanip>	//	FIXME	나중에 지우기 테스트용
+#include <cstdlib>	//	FIXME	나중에 지우기 테스트용
+#include "HttpMessageResponse.hpp"
+
+HttpMessageResponse::HttpMessageResponse(const HttpMessageRequest& request)
+	: mRequest(request)
+{
+	// if (mReasonPhrase.empty())
+	// {
+	// 	mReasonPhrase[100] = "Continue";
+	// 	mReasonPhrase[101] = "Switching Protocols";
+	// 	mReasonPhrase[103] = "Early Hints";
+	// 	mReasonPhrase[200] = "OK";
+	// 	mReasonPhrase[201] = "Created";
+	// 	mReasonPhrase[202] = "Accepted";
+	// 	mReasonPhrase[203] = "Non-Authoritative Information";
+	// 	mReasonPhrase[204] = "No Content";
+	// 	mReasonPhrase[205] = "Reset Content";
+	// 	mReasonPhrase[206] = "Partial Content";
+	// 	mReasonPhrase[300] = "Multiple Choices";
+	// 	mReasonPhrase[301] = "Moved Permanently";
+	// 	mReasonPhrase[302] = "Found";
+	// 	mReasonPhrase[303] = "See Other";
+	// 	mReasonPhrase[304] = "Not Modified";
+	// 	mReasonPhrase[307] = "Temporary Redirect";
+	// 	mReasonPhrase[308] = "Permanent Redirect";
+	// 	mReasonPhrase[400] = "Bad Request";
+	// 	mReasonPhrase[401] = "Unauthorized";
+	// 	mReasonPhrase[402] = "Payment Required";
+	// 	mReasonPhrase[403] = "Forbidden";
+	// 	mReasonPhrase[404] = "Not Found";
+	// 	mReasonPhrase[405] = "Method Not Allowed";
+	// 	mReasonPhrase[406] = "Not Acceptable";
+	// 	mReasonPhrase[407] = "Proxy Authentication Required";
+	// 	mReasonPhrase[408] = "Request Time-out";
+	// 	mReasonPhrase[409] = "Conflict";
+	// 	mReasonPhrase[410] = "Gone";
+	// 	mReasonPhrase[411] = "Length Required";
+	// 	mReasonPhrase[412] = "Precondition Failed";
+	// 	mReasonPhrase[413] = "Request Entity Too Large";
+	// 	mReasonPhrase[414] = "Request-URI Too Large";
+	// 	mReasonPhrase[415] = "Unsupported Media Type";
+	// 	mReasonPhrase[416] = "Requested range not satisfiable";
+	// 	mReasonPhrase[417] = "Expectation Failed";
+	// 	mReasonPhrase[418] = "I'm a teapot";
+	// 	mReasonPhrase[422] = "Unprocessable Entity";
+	// 	mReasonPhrase[425] = "Too Early";
+	// 	mReasonPhrase[426] = "Upgrade Required";
+	// 	mReasonPhrase[428] = "Precondition Required";
+	// 	mReasonPhrase[429] = "Too Many Requests";
+	// 	mReasonPhrase[431] = "Request Header Fields Too Large";
+	// 	mReasonPhrase[451] = "Unavailable For Legal Reasons";
+	// 	mReasonPhrase[500] = "Internal Server Error";
+	// 	mReasonPhrase[501] = "Not Implemented";
+	// 	mReasonPhrase[502] = "Bad Gateway";
+	// 	mReasonPhrase[503] = "Service Unavailable";
+	// 	mReasonPhrase[504] = "Gateway Time-out";
+	// 	mReasonPhrase[505] = "HTTP Version not supported";
+	// 	mReasonPhrase[506] = "Variant Also Negotiates";
+	// 	mReasonPhrase[507] = "Insufficient Storage";
+	// 	mReasonPhrase[508] = "Loop Detected";
+	// 	mReasonPhrase[510] = "Not Extended";
+	// 	mReasonPhrase[511] = "Network Authentication Required";
+	// }
+}
+
+HttpMessageResponse::~HttpMessageResponse(void)
+{
+}
+
+void				HttpMessageResponse::setStatusLine(void)
+{
+	// int	statusCode = 200;
+	mMessage += "HTTP/1.1";
+	mMessage += " ";
+	// mMessage += itoa(statusCode);	//	REVIEW : itoa 허용함수 인지
+	mMessage += "200";
+	mMessage += " ";
+	// mMessage += mReasonPhrase[200];
+	mMessage += "OK";
+	mMessage += "\r\n";
+}
+
+void				HttpMessageResponse::setHeaderField(void)
+{
+}
+
+void				HttpMessageResponse::setMessageBody(void)
+{
+	mMessage += "<h1>Hello World</h1>";
+	mMessage += "<h1>This is 200 OK!</h1>";
+}
+
+void				HttpMessageResponse::SetMessage(void)
+{
+	setStatusLine();
+	setHeaderField();
+	mMessage += "\r\n";
+	setMessageBody();
+}
+
+const std::string&	HttpMessageResponse::GetMessage(void) const
+{
+	return (mMessage);
+}

--- a/srcs/HttpMessage/HttpMessageResponse.hpp
+++ b/srcs/HttpMessage/HttpMessageResponse.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "HttpMessageRequest.hpp"
+
+class HttpMessageResponse
+{
+public:
+    HttpMessageResponse(const HttpMessageRequest& request);
+    ~HttpMessageResponse(void);
+
+   	void 				SetMessage(void);
+   	const std::string&	GetMessage(void) const;
+
+private:
+   	void setStatusLine(void);
+	void setHeaderField(void);
+	void setMessageBody(void);
+
+	const HttpMessageRequest&			mRequest;
+	std::string							mMessage;
+	static std::map<int, std::string>	mReasonPhrase;
+
+    // std::map<std::string, std::string>	mHeaderField;
+};

--- a/srcs/Socket.cpp
+++ b/srcs/Socket.cpp
@@ -34,7 +34,7 @@ Socket::Socket(int fd)
 
 Socket::~Socket()
 {
-	std::cout << "~Socket()\n";
+	// std::cout << "~Socket()\n";
 }
 
 void					Socket::SetAddr(void)
@@ -56,7 +56,7 @@ void					Socket::Bind(uint16_t port, uint32_t ip)
 		std::cout << "Failed to bind to port " << port << ". errno: " << errno << std::endl;
 		exit(EXIT_FAILURE);
 	}
-	std::cout << "finished binding\n";
+	// std::cout << "finished binding\n";
 }
 
 void					Socket::Listen(void)
@@ -67,7 +67,7 @@ void					Socket::Listen(void)
 		std::cout << "Failed to listen on socket. errno: " << errno << std::endl;
 		exit(EXIT_FAILURE);
 	}
-	std::cout << "finished listening\n";
+	// std::cout << "finished listening\n";
 }
 
 size_t					Socket::Accept(size_t connections)
@@ -80,7 +80,7 @@ size_t					Socket::Accept(size_t connections)
 		std::cout << "Failed to grab connection. errno: " << errno << std::endl;
 		exit(EXIT_FAILURE);
 	}
-	std::cout << "finished accepting\n";
+	// std::cout << "finished accepting\n";
 	return (connections);
 }
 

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,38 +1,50 @@
 #include "../base_headers/Socket.hpp"
-#include <fstream>
-#include <sstream>
-#include <string.h> // memset forbidden
+#include "HttpMessage/HttpMessageRequest.hpp"
+#include "HttpMessage/HttpMessageResponse.hpp"
 
+#include <fstream>	//	FIXME	나중에 지우기 테스트용
+#include <sstream>	//	FIXME	나중에 지우기 테스트용
+#include <string.h>	//	FIXME	나중에 지우기 테스트용
 
-int main() {
+#define BUFFER_SIZE 1000000
+int main()
+{
 	// Create a socket (IPv4, TCP)
-	Socket socket(100, INADDR_ANY); // Listen 작업까지 되어 있는 소켓
+	Socket socket(80, INADDR_ANY); // Listen 작업까지 되어 있는 소켓
 	size_t connections;
 
 	connections = socket.Accept(connections);
 
 	/* 테스트 진행 */
-		// STUB Read from the connection
-		char buffer[1000];	memset(buffer, 0, 1000);
-		int bytesRead = read(connections, buffer, 1000);
-		std::cout << "The message was: " << buffer;
+		//	STUB : Read from the connection
+		char buffer[BUFFER_SIZE];	memset(buffer, 0, BUFFER_SIZE);	//	REVIEW : 전체 탐색하는 것들은 성능 개선의 여지가 있음
+		int bytesRead = read(connections, buffer, BUFFER_SIZE);
+		// std::cout << "The message was: " << buffer;
 
-		// STUB Send a message to the connection
-		std::stringstream resp;
-		std::ifstream header("./testcase/header.http");
-		std::ifstream body("./testcase/body.html");
+		//	STUB : HttpMessageRequest
+		HttpMessageRequest	request(buffer);
+		request.Parser();
 
-		resp << header.rdbuf() << "\r\n" << body.rdbuf();
+		//	STUB : HttpMessageResponse
+		HttpMessageResponse	response(request);
+		response.SetMessage();
 
-		std::string response = resp.str();
-		int len = response.size();
+		//	STUB : Send a message to the connection
+		// std::stringstream resp;
+		// std::ifstream header("./testcase/header.http");
+		// std::ifstream body("./testcase/body.html");
 
-		std::cout << "Answer is :\n";
-		std::cout << response << std::endl;
+		// resp << header.rdbuf() << "\r\n" << body.rdbuf();
 
-		std::cout << "Wrote " << len  << " bytes" << '\n';
-		int ret = send(connections, response.c_str(), len, 0);
-		std::cout << "Wrote " << len  << " bytes, sent " << ret << '\n';
+		// std::string response = resp.str();
+		int len = response.GetMessage().size();
+
+		// std::cout << "Answer is :\n";
+		// std::cout << response << std::endl;
+
+		// std::cout << "Wrote " << len  << " bytes" << '\n';
+		int ret = send(connections, response.GetMessage().c_str(), len, 0);
+		// std::cout << "Wrote " << len  << " bytes, sent " << ret << '\n';
 
 	// Close the connections
 	close(connections);

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -6,7 +6,7 @@
 #include <sstream>	//	FIXME	나중에 지우기 테스트용
 #include <string.h>	//	FIXME	나중에 지우기 테스트용
 
-#define BUFFER_SIZE 1000000
+#define BUFFER_SIZE 65536
 int main()
 {
 	// Create a socket (IPv4, TCP)


### PR DESCRIPTION
## **WHAT?**
http request 파싱과 http response 전송 프로토타입을 구현함.
아주 최소한 내용만 구현한 것이고 동작만 가능하게 구현하였음.

## **WHY?**
http message의 일련의 과정들을 이해하기 위해.

## **TESTING**
- `HttpMessageRequest`는 클래스 내부에 테스트함수 구현
- `HttpMessageRespose`는 아주 최소 Message만 작성한거라 테스트할 내용도 없음

1. `Make`
2. 브라우저에서 `http://localhost`

## ISSUE and REFERENCE
Resolves: #16
See also: #7

@PennyBlack2008 추가한 부분이 겹치는 부분이 있어서 확인해주어야 함