### PR TITLE
Fix: timeout 이후 연결가능

### DIFF
--- a/srcs/Webserver/Webserver.cpp
+++ b/srcs/Webserver/Webserver.cpp
@@ -35,11 +35,12 @@ void Webserver::start_server(void)
 
 	while (1)
 	{
+		fd_set cpy_readfds = readfds; // STUB : 서버 소켓들을 보관할 fd_set 변수
 		timeout.tv_sec = 5;
 		timeout.tv_usec = 0;
 
 		/* STUB 4. select */
-		if((ret = select(fd_max + 1, &readfds, NULL, NULL, &timeout)) == -1)
+		if((ret = select(fd_max + 1, &cpy_readfds, NULL, NULL, &timeout)) == -1)
 		{
 			std::cout << "Select error\n";
 			break ;


### PR DESCRIPTION
## **WHAT?**

``select`` 함수에서 timeout 시에 ``readfds`` 값이 수정된다. 그래서 select 함수가 적용된 반복 loop 의 초반에 ``cpy_readfds`` 를  선언하여 ``readfds`` 의 복사본으로 만든 후, ``cpy_readfds`` 로 ``select`` 함수에 적용시킨다.

## **WHY?**

``select`` 함수에서 왜 내부적으로 이렇게 작동하는 지는 잘 모르겠으나 ``readfds`` 가 timeout 이후에 변경된다. 그래서 복사본을 만들어 ``select`` 함수에 적용시켰음. 

## **TESTING**

이 testcase 를 확인하려면, 실행파일을 실행시킨 후, 5초 뒤에 timeout 메시지가 나오고 접속을 시도해보면 된다.

## ISSUE and REFERENCE

* resolved #25 

## 덧붙이고 싶은 말

이제 서버 소켓이 여러개 생기고 client socket 에서도 정보를 주고 받게 된다면, select 함수에 필요한 원본 readfds 와 복사본 readfs, FD_SET, FD_CLR, FD_ISSET 을 사용하여 적절히 조작하는 것이 필요할 것임. 아직 공부와 테스트 경험이 부족해서 하고 있는 중임.