### PR TITLE
Refact: Webserver::start_server 를 start_servers 와 start_a_server 로 나눔

### DIFF
--- a/srcs/Server/Socket.cpp
+++ b/srcs/Server/Socket.cpp
@@ -5,6 +5,7 @@
 
 /* STUB : Socket 에 이런식으로 넣으면 binding, listen 작업까지 */
 Socket::Socket(uint32_t ip, uint16_t port)
+	: client_socket(-1)
 {
 	fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (fd == -1)
@@ -74,15 +75,15 @@ void					Socket::Listen(void)
 }
 
 /* STUB : Accept 작업. */
-size_t					Socket::Accept(size_t connections)
+size_t					Socket::Accept(void)
 {
 	// Grab a connection from the queue
 	socklen = sizeof(sockaddr);
-	connections = accept(fd, (struct sockaddr*)&sockaddr, (socklen_t*)&socklen);
-	if (connections < 0)
+	client_socket = accept(fd, (struct sockaddr*)&sockaddr, (socklen_t*)&socklen);
+	if (client_socket < 0)
 		throw (accept_failed_exception());
 	// std::cout << "finished accepting\n";
-	return (connections);
+	return (client_socket);
 }
 
 /* STUB : fd 를 반환함. */

--- a/srcs/Server/Socket.hpp
+++ b/srcs/Server/Socket.hpp
@@ -8,6 +8,7 @@
 class Socket : public sockaddr // REVIEW sockaddr 구조체는 쓰지않고 sockaddr_in으로 충분하기 때문에 상속관계를 지워도 될 꺼 같다.
 {
 	int			fd;
+	int			client_socket;
 	socklen_t	socklen;
 	sockaddr_in	sockaddr; // <-- 추가함.
 
@@ -23,7 +24,7 @@ class Socket : public sockaddr // REVIEW sockaddr 구조체는 쓰지않고 sock
 	void		Bind(uint32_t ip, uint16_t port);
 	void		Listen(void);
 	// void		Listen(size_t connections); // connection 은 뭘까?
-	size_t		Accept(size_t connections);
+	size_t		Accept(void);
 	// void		Accept(int servSock); // servSock 은 뭘까?
 	int			GetFd(void); // socket fd 를 close 를 main 에서 하기 위한
 

--- a/srcs/Webserver/Webserver.cpp
+++ b/srcs/Webserver/Webserver.cpp
@@ -15,7 +15,7 @@ void Webserver::start_server(void)
 	Servers &servers = this->mservers; // NOTE yunslee
 	servers.SetSockets(); // NOTE yunslee
 
-	
+
 	// Socket socket_one(INADDR_ANY, 8000); // STUB : Server socket 윤성이의 config 에 따라 ip, port 번호가 주어짐.
 	int client_socket; // STUB : Accept 의 반환값을 받아 만들어지는 통신 소켓
 	char buffer[BUFFER_SIZE]; // STUB : 버퍼. 버퍼사이즈는 위에 define 되어 있음.
@@ -31,7 +31,7 @@ void Webserver::start_server(void)
 	/* STUB 1. clear the socket set */
 	FD_ZERO(&readfds);
 
-	/* STUB 2. add master socket to set */ 
+	/* STUB 2. add master socket to set */
 	for (size_t i = 0; i < servers.mservers.size(); i++) // NOTE yunslee
 	{
 		Server &server = servers.mservers[i];
@@ -44,7 +44,7 @@ void Webserver::start_server(void)
 	std::cout << "fd_max: " << fd_max << std::endl;
 	while (1)
 	{
-		timeout.tv_sec = 2; timeout.tv_usec = 0; 
+		timeout.tv_sec = 2; timeout.tv_usec = 0;
 		fd_set cpy_readfds = readfds; // STUB : 서버 소켓들을 보관할 fd_set 변수
 		/* STUB 4. select */
 		if((ret = select(fd_max + 1, &cpy_readfds, NULL, NULL, &timeout)) == -1)
@@ -69,7 +69,7 @@ void Webserver::start_server(void)
 			if (FD_ISSET(server.msocket.GetFd(), &cpy_readfds))
 			{
 				// std::cerr << "ret is " << ret << std::endl;
-				client_socket = server.msocket.Accept(client_socket);
+				client_socket = server.msocket.Accept();
 				if (client_socket == -1)
 					std::cerr << "Could not create socket." << std::endl;
 				else
@@ -109,7 +109,7 @@ void Webserver::start_server(void)
 		}
 	}
 
-	 // STUB : close all server socket 
+	 // STUB : close all server socket
 	for (size_t i = 0; i < servers.mservers.size(); i++) // NOTE yunslee 서버 소켓 다 닫아야함.
 	{
 		Server &server = servers.mservers[i];

--- a/srcs/Webserver/Webserver.cpp
+++ b/srcs/Webserver/Webserver.cpp
@@ -12,20 +12,13 @@ Webserver::Webserver(int argc, char** argv, char** envp)
 	(void)envp;
 }
 
-void Webserver::start_server(void)
+void Webserver::start_servers(void)
 {
 	Servers &servers = this->mservers; // NOTE yunslee
 	servers.SetSockets(); // NOTE yunslee
 
-	int client_socket; // STUB : Accept 의 반환값을 받아 만들어지는 통신 소켓
-	char buffer[BUFFER_SIZE]; // STUB : 버퍼. 버퍼사이즈는 위에 define 되어 있음.
-	int bytesRead = BUFFER_SIZE - 1; // STUB : read 를 얼마나 했는 지 받는 변수. read 반복문에 들어가기 위해 초기화를 해준다.
 	int ret; // STUB : select 의 반환 값을 받아. -1: error, 0: timeout, 그외 성공.
 	int fd_max; // STUB : 가장 fd 번호가 늦는 서버 소켓을 저장. select 가 이 값을 참고해 서버 소켓의 변화를 확인한다.
-
-
-	/* TEST : 테스트 진행 */
-	bytesRead = BUFFER_SIZE - 1;
 
 	/* STUB 1. clear the socket set */
 	FD_ZERO(&readfds);
@@ -60,56 +53,62 @@ void Webserver::start_server(void)
 			std::cout << "Received connection\n";
 		}
 
-		/* STUB 4. FD_ISSET 서버 소켓 버퍼 감시 */
+		/* STUB 5. FD_ISSET 서버 소켓 버퍼 감시 */
 		for (size_t i = 0; i < servers.mservers.size(); i++) // NOTE yunslee port별로 ISSET 확인하기 위해서 반복문 씀
 		{
 			Server &server = servers.mservers[i];
 			if (FD_ISSET(server.msocket.GetFd(), &cpy_readfds))
-			{
-				client_socket = server.msocket.Accept();
-				if (client_socket == -1)
-					std::cerr << "Could not create socket." << std::endl;
-				else
-				{
-					bytesRead = BUFFER_SIZE - 1;
-					std::cout << "connected client fd: " << client_socket << std::endl;
-
-					//	STUB : Read from the connection
-					while (bytesRead == BUFFER_SIZE - 1)
-					{
-						ft_memset(buffer, 0, BUFFER_SIZE);	//	REVIEW : 전체 탐색하는 것들은 성능 개선의 여지가 있음
-						bytesRead = read(client_socket, buffer, BUFFER_SIZE - 1); // request 를 여기서 받아서..
-						/***************************************************
-						 * 영환이가 버퍼를 받아 코드에서 적용시키는 영역
-						 ***************************************************/
-						if (bytesRead == -1)
-							std::cerr << "Could not read request." << std::endl;
-					}
-					if (bytesRead != -1)
-					{
-						//	STUB : HttpMessageRequest
-						HttpMessageRequest	request(buffer);
-						request.Parser(); // request 를 parsing 한 후,
-
-						//	STUB : HttpMessageResponse
-						HttpMessageResponse	response(request); // reponse 를 정리한다.
-						response.SetMessage();
-
-						//	STUB : Send a message to the connection
-						int len = response.GetMessage().size();
-						int ret = send(client_socket, response.GetMessage().c_str(), len, 0);
-					}
-				}
-				// STUB Close the connections
-				close(client_socket);
-			}
+				start_a_server(server, cpy_readfds);
 		}
 	}
-
-	 // STUB : close all server socket
+	// STUB : close all server socket
 	for (size_t i = 0; i < servers.mservers.size(); i++) // NOTE yunslee 서버 소켓 다 닫아야함.
 	{
 		Server &server = servers.mservers[i];
 		close(server.msocket.GetFd());
 	}
+}
+
+void Webserver::start_a_server(Server& server, fd_set& cpy_readfds)
+{
+	int client_socket; // STUB : Accept 의 반환값을 받아 만들어지는 통신 소켓
+	char buffer[BUFFER_SIZE]; // STUB : 버퍼. 버퍼사이즈는 위에 define 되어 있음.
+	int bytesRead; // STUB : read 를 얼마나 했는 지 받는 변수. read 반복문에 들어가기 위해 초기화를 해준다.
+
+	client_socket = server.msocket.Accept();
+	if (client_socket == -1)
+		std::cerr << "Could not create socket." << std::endl;
+	else
+	{
+		bytesRead = BUFFER_SIZE - 1;
+		std::cout << "connected client fd: " << client_socket << std::endl;
+
+		//	STUB : Read from the connection
+		while (bytesRead == BUFFER_SIZE - 1)
+		{
+			ft_memset(buffer, 0, BUFFER_SIZE);	//	REVIEW : 전체 탐색하는 것들은 성능 개선의 여지가 있음
+			bytesRead = read(client_socket, buffer, BUFFER_SIZE - 1); // request 를 여기서 받아서..
+			/***************************************************
+			 * 영환이가 버퍼를 받아 코드에서 적용시키는 영역
+			 ***************************************************/
+			if (bytesRead == -1)
+				std::cerr << "Could not read request." << std::endl;
+		}
+		if (bytesRead != -1)
+		{
+			//	STUB : HttpMessageRequest
+			HttpMessageRequest	request(buffer);
+			request.Parser(); // request 를 parsing 한 후,
+
+			//	STUB : HttpMessageResponse
+			HttpMessageResponse	response(request); // reponse 를 정리한다.
+			response.SetMessage();
+
+			//	STUB : Send a message to the connection
+			int len = response.GetMessage().size();
+			int ret = send(client_socket, response.GetMessage().c_str(), len, 0);
+		}
+	}
+	// STUB Close the connections
+	close(client_socket);
 }

--- a/srcs/Webserver/Webserver.cpp
+++ b/srcs/Webserver/Webserver.cpp
@@ -5,6 +5,8 @@
 
 Webserver::Webserver(int argc, char** argv, char** envp)
 {
+	this->timeout.tv_sec = 2;
+	this->timeout.tv_usec = 0;
 	(void)argc;
 	(void)argv;
 	(void)envp;
@@ -15,15 +17,12 @@ void Webserver::start_server(void)
 	Servers &servers = this->mservers; // NOTE yunslee
 	servers.SetSockets(); // NOTE yunslee
 
-
-	// Socket socket_one(INADDR_ANY, 8000); // STUB : Server socket 윤성이의 config 에 따라 ip, port 번호가 주어짐.
 	int client_socket; // STUB : Accept 의 반환값을 받아 만들어지는 통신 소켓
 	char buffer[BUFFER_SIZE]; // STUB : 버퍼. 버퍼사이즈는 위에 define 되어 있음.
 	int bytesRead = BUFFER_SIZE - 1; // STUB : read 를 얼마나 했는 지 받는 변수. read 반복문에 들어가기 위해 초기화를 해준다.
-	fd_set readfds; // STUB : 서버 소켓들을 보관할 fd_set 변수
 	int ret; // STUB : select 의 반환 값을 받아. -1: error, 0: timeout, 그외 성공.
 	int fd_max; // STUB : 가장 fd 번호가 늦는 서버 소켓을 저장. select 가 이 값을 참고해 서버 소켓의 변화를 확인한다.
-	timeval	timeout; // STUB : timeout 시간 설정.
+
 
 	/* TEST : 테스트 진행 */
 	bytesRead = BUFFER_SIZE - 1;
@@ -41,11 +40,10 @@ void Webserver::start_server(void)
 	/* STUB 3. 여러개의 socket_fd 중에서 Get 하기 */
 	fd_max = this->mservers.GetFdMax(); // NOTE yunslee
 
-	std::cout << "fd_max: " << fd_max << std::endl;
 	while (1)
 	{
-		timeout.tv_sec = 2; timeout.tv_usec = 0;
 		fd_set cpy_readfds = readfds; // STUB : 서버 소켓들을 보관할 fd_set 변수
+
 		/* STUB 4. select */
 		if((ret = select(fd_max + 1, &cpy_readfds, NULL, NULL, &timeout)) == -1)
 		{
@@ -68,7 +66,6 @@ void Webserver::start_server(void)
 			Server &server = servers.mservers[i];
 			if (FD_ISSET(server.msocket.GetFd(), &cpy_readfds))
 			{
-				// std::cerr << "ret is " << ret << std::endl;
 				client_socket = server.msocket.Accept();
 				if (client_socket == -1)
 					std::cerr << "Could not create socket." << std::endl;

--- a/srcs/Webserver/Webserver.hpp
+++ b/srcs/Webserver/Webserver.hpp
@@ -11,11 +11,13 @@
 
 class Webserver
 {
+	timeval	timeout; // STUB : timeout 시간 설정.
 public:
 	// ConfigWebserver			config;
 	// fd_set					to_be_checked;
 	// fd_set					to_be_checked_read;
 	// fd_set					to_be_checked_write;
+	fd_set readfds; // STUB : 서버 소켓들을 보관할 fd_set 변수
 	Servers			mservers;
 
 public:

--- a/srcs/Webserver/Webserver.hpp
+++ b/srcs/Webserver/Webserver.hpp
@@ -22,7 +22,8 @@ public:
 
 public:
 	Webserver(int argc, char** argv, char** envp);
-	void			start_server(void);				// 서버 시작
+	void			start_servers(void);				// 서버 시작
+	void			start_a_server(Server& server, fd_set& cpy_readfds); // 서버 하나 시작
 					// Webserver(const Path&); 	// config 파일의 경로를 받아서 초기화
 	// void			create_server(const std::vector<Config>& config_locations);
 

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -26,7 +26,7 @@ int		main(int argc, char** argv, char** env)
 
 
 		s.mservers = servers; // REVIEW public으로 값을 할당하는데, soft 할지 deep할지
-		s.start_server();
+		s.start_servers();
 	}
 	catch(const std::exception &e) {
 		std::cerr << e.what() << std::endl;


### PR DESCRIPTION
## **WHAT?**

 ``start_server`` 를 ``start_servers`` 와 ``start_a_server`` 로 나누었음.

 - ``start_servers`` 에서는 ``select`` 가 소켓들을 감시하기 위한 코드
 - ``start_a_server`` 에서는 서버 소켓에서 버퍼를 받으며 ``request`` 와 ``response`` 를 하는 함수를 넣었음.

 **기타 사항**

 ``Socket::Accept`` 에 들어있던 ``int connection`` 파라미터를 ``int client`` 클래스 변수로 바꿨음. resolved #27

 ``readfds`` 를 모든 클래스함수에서 접근할 수 있도록 클래스 변수로 바꿨음.

## **WHY?**

  ``start_server`` 가 서버 여러개를 돌리는 데, 그 이름에 걸맞지 않게 모든 ``server`` 를 제어하고 너무 코드수가 많기 때문에 ``start_servers`` 로 이름을 변경하고 코드를 나눌 필요가 있었음.

## **TESTING**

 make 로 수행해서 이전과 똑같이 8000, 8001, 8002 번이 잘 작동하는 지 확인한다. 특별히 기능을 추가한 것은 없다.

## **개선해야할 사항**

 request 와 response 로 클라이언트와 주고 받게 된다면 진정한 멀티플랙싱을 구현해야할 때가 올 것임. 지금은 클라이언트 소켓에서 request 를 받고 끝나지만, 클라이언트 소켓에서 request 를 주고 받는 것을 반복적으로 가능하게 하려면, readfds 에 클라이언트 소켓을 추가해야할 것이다. 그리고 클라이언트 소켓에서 연결이 끊어진 상태라면, readfds 에서 FD_CLR 을 사용하여 readfds 에서 클라이언트 소켓을 제거해야한다.

 이렇게 수정할 사항들이 많아서 더 깔끔하게 Webserver 클래스 함수들을 정리할 수 있었지만, 하나의 함수에 서버의 사이클이 있는 게 나중에 수정하기가 편할 것같아서 일단 여기까지 두었음.

 아직 공부가 충분하지 못해서 이 부분이 감이 안잡히는 데, 일단 request 와 response 에 대한 충분한 이해가 있어야 그림이 나올 것같아서 그것부터 공부를 해보겠음.

