### PR TITLE
Feat: createServer 함수 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,9 @@ fclean	:	clean
 
 re		:	fclean all
 
-$(NAME)	:	$(OBJS)
-# $(CC) -c $(SRCS)
-			# $(CC) $(CFLAG) $(OBJS) -o $(NAME)
-			$(CC) $(SRCS) -o $(NAME)
-			./webserv
-# $(CC) $(CFLAG) -o $(NAME) $(OBJS)
+$(NAME)		:	$(OBJS)
+				$(CC) $(CFLAGS) $^ -o $@
+				./webserv
 
 .PHONY	:	all clean fclean re
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SRCS	=	srcs/main.cpp\
-			srcs/ServerManager.cpp
+			srcs/ServerManager.cpp\
+			srcs/Server.cpp\
+			srcs/Config.cpp\
+			srcs/Location.cpp
 
 # $(wildcard ./srcs/*.cpp)
 

--- a/srcs/Config.cpp
+++ b/srcs/Config.cpp
@@ -1,0 +1,20 @@
+#include "Config.hpp"
+
+Config::Config(void)
+{
+}
+
+Config::Config(std::string config_block, char** envp)
+{
+	
+}
+
+Config&			Config::operator=(const Config& other)
+{
+	m_software_name = other.m_software_name;
+	m_software_version = other.m_software_version;
+	m_http_version = other.m_http_version;
+	m_cgi_version = other.m_cgi_version;
+	m_base_env = other.m_base_env;
+	return (*this);
+}

--- a/srcs/Config.hpp
+++ b/srcs/Config.hpp
@@ -5,21 +5,24 @@
 
 class Config
 {
-public:
-	Config(config_block, env);
+	public:
+		Config(void);
+		Config(std::string config_block, char** envp);
 
-	const std::string&	get_m_software_name(void) const;
-	const std::string&	get_m_softwrae_version(void) const;
-	const std::string&	get_m_http_version(void) const;
-	const std::string&	get_m_cgi_version(void) const;
-	const char**		get_m_base_env(void) const;
+		Config&				operator=(const Config& other);
 
-private:
-	std::string			m_software_name;
-	std::string			m_software_version;
-	std::string			m_http_version;
-	std::string			m_cgi_version;
-	char**				m_base_env;
+		const std::string&	get_m_software_name(void) const;
+		const std::string&	get_m_softwrae_version(void) const;
+		const std::string&	get_m_http_version(void) const;
+		const std::string&	get_m_cgi_version(void) const;
+		const char**		get_m_base_env(void) const;
+
+	private:
+		std::string			m_software_name;
+		std::string			m_software_version;
+		std::string			m_http_version;
+		std::string			m_cgi_version;
+		char**				m_base_env;
 };
 
 #endif

--- a/srcs/Location.cpp
+++ b/srcs/Location.cpp
@@ -1,0 +1,6 @@
+#include "Location.hpp"
+
+Location::Location(std::string location_block)
+{
+
+}

--- a/srcs/Location.hpp
+++ b/srcs/Location.hpp
@@ -7,7 +7,7 @@
 class Location
 {
 public:
-	Location(location_block);
+	Location(std::string location_block);
 
 	const std::string&							get_m_uri(void) const;
 	const std::string&							get_m_root_path(void) const;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1,0 +1,52 @@
+#include "Server.hpp"
+
+// Server 생성자
+// 이미 유효성 검사가 끝난 safety block들이 인자로 들어오기 때문에, Server 생성자에서 해야 하는 작업은 많지 않습니다.
+// server_block을 파싱하여 Server 인스턴스의 멤버 변수에 값을 저장하고, location block들은 그대로 Location 생성자에 넘겨 Server 인스턴스의 벡터 멤버 변수에 저장합니다.
+// 그 외에는 일반적인 서버 프로그램과 같습니다.
+
+Server::Server(ServerManager* server_manager, const std::string& server_block, std::vector<std::string>& location_blocks, Config* config)
+	: m_manager(server_manager)
+	, m_config(config)
+{
+	if((m_fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1)
+	{
+		throw std::runtime_error("SOCKET ERROR");
+	}
+
+	int	value = 1;
+	if (setsockopt(m_fd, SOL_SOCKET, SO_REUSEADDR, &value, sizeof(int)) == -1)
+	{
+		throw std::runtime_error("SOCKET_OPTION ERROR");
+	}
+
+	struct sockaddr_in	server_addr;
+	memset(&server_addr, 0, sizeof(struct sockaddr_in));
+	server_addr.sin_family = AF_INET;
+	// NOTE: 임시로 localhost:80으로 설정
+	m_host = "localhost";
+	m_port = 80;
+	server_addr.sin_addr.s_addr = inet_addr(m_host.c_str());
+	server_addr.sin_port = htons(m_port);
+	
+	if(bind(m_fd, reinterpret_cast<struct sockaddr *>(&server_addr), sizeof(struct sockaddr)) == -1)
+	{
+		throw std::runtime_error("BIND ERROR");
+	}
+	if(listen(m_fd, 256) == -1)
+	{
+		throw std::runtime_error("LISTEN ERROR");
+	}
+	if (fcntl(m_fd, F_SETFL, O_NONBLOCK) == -1)
+	{
+		throw std::runtime_error("FCNTL ERROR");
+	}
+
+	// location block들은 그대로 Location 생성자에 넘겨 Server 인스턴스의 벡터 멤버 변수에 저장
+	for (std::vector<std::string>::iterator it = location_blocks.begin(); it != location_blocks.end(); ++it)
+	{
+		m_locations.push_back(Location(*it));
+	}
+}
+
+const int&					Server::get_m_fd(void) const	{ return (m_fd); }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -24,8 +24,8 @@ Server::Server(ServerManager* server_manager, const std::string& server_block, s
 	memset(&server_addr, 0, sizeof(struct sockaddr_in));
 	server_addr.sin_family = AF_INET;
 	// NOTE: 임시로 localhost:80으로 설정
-	m_host = "localhost";
-	m_port = 80;
+	m_host = "127.0.0.1";
+	m_port = 8080;
 	server_addr.sin_addr.s_addr = inet_addr(m_host.c_str());
 	server_addr.sin_port = htons(m_port);
 	

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -5,56 +5,76 @@
 #include <vector>
 #include <queue>
 #include <map>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+
 #include "Location.hpp"
 #include "Config.hpp"
 #include "ServerManager.hpp"
-#include "Connection.hpp"
-#include "Request.hpp"
-#include "Response.hpp"
+class ServerManager;
+// #include "Connection.hpp"
+// #include "Request.hpp"
+// #include "Response.hpp"
 
 class Server
 {
-public:
-	Server(ServerManager*, Server server_block, Location location_blocks, Config*);
+	public:
+		Server(ServerManager* server_manager, const std::string& server_block, std::vector<std::string>& location_blocks, Config* config);
 
-	bool						hasException(int client_fd);
-	void						closeConnection(int client_fd);
-	void						isSendable(int client_fd);
-	void						sendResponse(Response response);
-	void						hasRequest(int client_fd);
-	Request						recvRequest(int client_fd);
-	void						solveRequest(Request request);
-	void						executeAutoindex(void);
-	void						executeGet(Request request);
-	void						executeHead(Request request);
-	void						executePut(Request request);
-	void						executePost(Request request);
-	void						executeDelete(Request request);
-	void						executeOptions(Request request);
-	void						executeTrace(Request request);
-	char**						createCGIEnv(void);
-	void						executeCGI(Request request);
-	void						createResponse(int status_code);
-	bool						hasNewConnection(void);
-	void						acceptNewConnection(void);
-	void						run(void);
+		// bool						hasException(int client_fd);
+		// void						closeConnection(int client_fd);
+		// void						isSendable(int client_fd);
+		// Request						recvRequest(int client_fd);
+		// void						sendResponse(Response response);
+		// char**						createCGIEnv(void);
+		// bool						hasNewConnection(void);
+		// void						acceptNewConnection(void);
 
 
+		// int							getUnuseConnectionFd();
+		// bool						parseStartLine(Connection& connection, Request& request);
+		// bool						parseHeader(Connection& connection, Request& request);
+		// bool						parseBody(Connection& connection, Request& request);
 
-private:
-	ServerManager*				m_manager;
-	std::string					m_server_name;
-	std::string					m_host;
-	int							m_port;
-	int							m_fd;
-	int							m_request_uri_limit_size;
-	int							m_request_header_limit_size;
-	int							m_limit_client_body_size;
-	std::string					m_default_error_page;
-	Config*						m_config;
-	std::vector<Location>		m_locations;
-	std::map<int, Connection>	m_connections;
-	std::queue<Response>		m_responses;
+		// bool						hasRequest(Connection& connection);
+		// bool						runRecvAndSolve(Connection& connection);
+		// bool						hasExecuteWork(Connection& connection);
+		// bool						runExecute(Connection& connection);
+		// bool						hasSendWork(Connection& connection);
+		// bool						runSend(Connection& connection);
+
+		// void						run(void);
+		// void						solveRequest(Connection& connection, const Request& request);
+		// void						executeAutoindex(Connection& connection, const Request& request);
+		// void						executeGet(Connection& connection, const Request& request);
+		// void						executeHead(Connection& connection, const Request& request);
+		// void						executePost(Connection& connection, const Request& request);
+		// void						executePut(Connection& connection, const Request& request);
+		// void						executeDelete(Connection& connection, const Request& request);
+		// void						executeOptions(Connection& connection, const Request& request);
+		// void						executeTrace(Connection& connection, const Request& request);
+		// void						executeCGI(Connection& connection, const Request& request);
+		// void						createResponse(Connection& connection, int status, headers_t headers = headers_t(), std::string body = "");
+
+		const int&					get_m_fd(void) const;
+
+	private:
+		ServerManager*				m_manager;
+		// std::string					m_server_name;
+		std::string					m_host;
+		int							m_port;
+		int							m_fd;
+		// int							m_request_uri_limit_size;
+		// int							m_request_header_limit_size;
+		// int							m_limit_client_body_size;
+		// std::string					m_default_error_page;
+		Config*						m_config;
+		std::vector<Location>		m_locations;
+		// std::map<int, Connection>	m_connections;
+		// std::queue<Response>		m_responses;
 };
 
 #endif

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -48,7 +48,7 @@ void	ServerManager::createServer(const std::string& configuration_file_path, cha
 	// 	// 	}
 	// 	// }
 		m_servers.push_back(Server(this, server_block, location_blocks, &this->m_config));
-		m_server_fdset.insert(m_servers.back().get_m_fd());
+		m_server_fdset.insert(m_servers.back().get_m_fd()); // REVIEW: 이유가 있으니 이런 코드가 있겠지만 의미하는 바를 파악하지 못했음
 	}
 	// // writeCreateServerLog();
 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -11,9 +11,46 @@ void					ServerManager::exitServer(const std::string& msg) const
 	exit(1);
 }
 
-void					ServerManager::createServer(const std::string& configuration_file_path, char** envp)
+void	ServerManager::createServer(const std::string& configuration_file_path, char** envp)
 {
+	// // std::string					config_string = ft::getStringFromFile(configuration_file_path);
+	std::string					config_block;
+	std::vector<std::string>	server_strings;
 
+	// // if (!splitConfigString(config_string, config_block, server_strings))
+	// // {
+	// 	// throw (std::invalid_argument("Failed to split configuration string"));
+	// // }
+	// // if (!isValidConfigBlock(config_block))
+	// // {
+	// 	// throw (std::invalid_argument("Config block is not valid."));
+	// // }
+	m_config = Config(config_block, envp);
+
+	// NOTE : config 파싱에서 서버블록이 1개 있었다고 가정하고 작업
+	for (size_t i = 0; i < 1/*server_strings.size()*/; ++i)
+	{
+		std::string					server_block;
+		std::vector<std::string>	location_blocks;
+		// if (!splitServerString(server_strings[i], server_block, location_blocks))
+	// 	// {
+	// 	// 	throw (std::invalid_argument("Failed to split Sever string(" + ft::to_string(i) + ")"));
+	// 	// }
+	// 	// if (!isValidServerBlock(server_block))
+	// 	// {
+	// 	// 	throw (std::invalid_argument("Server block(" + ft::to_string(i) + ") is not valid."));
+	// 	// }
+	// 	// for (size_t j = 0; j < location_blocks.size(); ++j)
+	// 	// {
+	// 	// 	if (!isValidLocationBlock(location_blocks[j]))
+	// 	// 	{
+	// 	// 		throw (std::invalid_argument("Location block(" + ft::to_string(i) + "-" + ft::to_string(j) + ") is not valid."));
+	// 	// 	}
+	// 	// }
+		m_servers.push_back(Server(this, server_block, location_blocks, &this->m_config));
+		m_server_fdset.insert(m_servers.back().get_m_fd());
+	}
+	// // writeCreateServerLog();
 }
 
 void					ServerManager::runServer(void)

--- a/srcs/ServerManager.hpp
+++ b/srcs/ServerManager.hpp
@@ -5,7 +5,7 @@
 
 #include <iostream>
 #include <vector>
-// #include <sys/select.h> // REVIEW: FD_SET 을 위해 추가
+#include <sys/select.h> // REVIEW: FD_SET 을 위해 추가
 #include "Config.hpp" // REVIEW: 일단 추가
 #include "Server.hpp" // REVIEW: 일단 추가
 class Server;
@@ -21,17 +21,21 @@ class ServerManager
 		// const Config&		get_m_config(void) const;
 		// const int&			get_m_max_fd(void) const;
 		// void					set_m_config(const Config& config);
-		// void					set_m_max_fd(int fd);
+		void					set_m_max_fd(const int& fd);
 
-		// void					fdSet(int fd, int SetType); // REVIEW: SetType 이 enum 이라서 int 로 두었음
-		// void					fdZero(int SetType); // REVIEW: SetType 이 enum 이라서 int 로 두었음
-		// void					fdClear(int fd, int SetType); // REVIEW: SetType 이 enum 이라서 int 로 두었음
-		// void					fdIsset(int fd, int SetType); // REVIEW: SetType 이 enum 이라서 int 로 두었음
-		// void					fdCopy(int SetType); // REVIEW: SetType 이 enum 이라서 int 로 두었음
+		enum SetType		{ WRITE_SET, WRITE_COPY_SET, READ_SET, READ_COPY_SET, ERROR_SET, ERROR_COPY_SET, ALL_SET };
 
-		void					exitServer(const std::string& msg) const; // NOTE: 에러 메시지 출력 후 프로그램 종료
-		void					createServer(const std::string& configuration_file_path, char** envp); // NOTE: 서버 객체 생성
-		void					runServer(void); // NOTE: 관리하고 있는 전체 서버 실행
+		// void				fdSet(int fd, SetType fdset);
+		void				fdZero(SetType fdset);
+		// void				fdClear(int fd, SetType fdset);
+		bool				fdIsset(int fd, SetType fdset);
+		void				fdCopy(SetType fdset);
+
+		void				resetMaxFd(int new_max_fd);
+
+		void				exitServer(const std::string& msg) const; // NOTE: 에러 메시지 출력 후 프로그램 종료
+		void				createServer(const std::string& configuration_file_path, char** envp); // NOTE: 서버 객체 생성
+		void				runServer(void); // NOTE: 관리하고 있는 전체 서버 실행
 
 	private:
 		// bool					splitConfigString(config_string config_string, config_block config_block, std::vector<std::string> server_strings); // NOTE: config 파일을 config block/server strings로 분리
@@ -40,17 +44,16 @@ class ServerManager
 		// bool					isValidServerBlock(std::string server_block); // NOTE: server block 유효성 확인, ServerManager::creator 에 있는 함수 타입 참고하여 타입 수정
 		// bool					isValidLocationBlock(std::string location_block); // NOTE: location block 유효성 확인, ServerManager::creator 에 있는 함수 타입 참고하여 타입 수정
 
-		// enum SetType		{ WRITE_SET, WRITE_COPY_SET, READ_SET, READ_COPY_SET, ERROR_SET, ERROR_COPY_SET }; // NOTE: fd_set type
-		std::set<int>		m_server_fdset;	// FIXME: 존재이유 파악못했고, set 컨테이너 사용 불가
-		std::vector<Server>	m_servers; // NOTE: server 객체들
-		Config				m_config; // NOTE: configuration 파일을 파싱한 결과
-		// int					m_max_fd; // NOTE: 관리하는 서버의 max_fd 중 가장 큰 fd
-		// fd_set				m_read_set; // NOTE: 요청 발생여부 확인을 위한 fd_set
-		// fd_set				m_read_copy_set; // NOTE: select에 실제 인자로 넣을 read_set
-		// fd_set				m_write_set; // NOTE: 응답 송신 가능여부 확인을 위한 fd_set, enum 0 번.
-		// fd_set				m_write_copy_set; // NOTE: select에 실제 인자로 넣을 write_set
-		// fd_set				m_error_set; // NOTE: 예외 발생여부 확인을 위한 fd_set
-		// fd_set				m_error_copy_set; // NOTE: select에 실제 인자로 넣을 error_set
+		std::set<int>		m_server_fdset;		// FIXME: 존재이유 파악못했고, set 컨테이너 사용 불가
+		std::vector<Server>	m_servers;			// NOTE: server 객체들
+		Config				m_config;			// NOTE: configuration 파일을 파싱한 결과
+		int					m_max_fd;			// NOTE: 관리하는 서버의 max_fd 중 가장 큰 fd
+		fd_set				m_read_set;			// NOTE: 요청 발생여부 확인을 위한 fd_set
+		fd_set				m_read_copy_set;	// NOTE: select에 실제 인자로 넣을 read_set
+		fd_set				m_write_set;		// NOTE: 응답 송신 가능여부 확인을 위한 fd_set, enum 0 번.
+		fd_set				m_write_copy_set;	// NOTE: select에 실제 인자로 넣을 write_set
+		// fd_set				m_error_set;		// NOTE: 예외 발생여부 확인을 위한 fd_set
+		// fd_set				m_error_copy_set;	// NOTE: select에 실제 인자로 넣을 error_set
 
 
 

--- a/srcs/ServerManager.hpp
+++ b/srcs/ServerManager.hpp
@@ -6,9 +6,10 @@
 #include <iostream>
 #include <vector>
 // #include <sys/select.h> // REVIEW: FD_SET 을 위해 추가
-// #include "Config.hpp" // REVIEW: 일단 추가
-// #include "Server.hpp" // REVIEW: 일단 추가
-// #include "Location.hpp"  // REVIEW: 일단 추가
+#include "Config.hpp" // REVIEW: 일단 추가
+#include "Server.hpp" // REVIEW: 일단 추가
+class Server;
+#include "Location.hpp"  // REVIEW: 일단 추가
 
 
 
@@ -40,8 +41,9 @@ class ServerManager
 		// bool					isValidLocationBlock(std::string location_block); // NOTE: location block 유효성 확인, ServerManager::creator 에 있는 함수 타입 참고하여 타입 수정
 
 		// enum SetType		{ WRITE_SET, WRITE_COPY_SET, READ_SET, READ_COPY_SET, ERROR_SET, ERROR_COPY_SET }; // NOTE: fd_set type
-		// std::vector<Server>	m_servers; // NOTE: server 객체들
-		// Config				m_config; // NOTE: configuration 파일을 파싱한 결과
+		std::set<int>		m_server_fdset;	// FIXME: 존재이유 파악못했고, set 컨테이너 사용 불가
+		std::vector<Server>	m_servers; // NOTE: server 객체들
+		Config				m_config; // NOTE: configuration 파일을 파싱한 결과
 		// int					m_max_fd; // NOTE: 관리하는 서버의 max_fd 중 가장 큰 fd
 		// fd_set				m_read_set; // NOTE: 요청 발생여부 확인을 위한 fd_set
 		// fd_set				m_read_copy_set; // NOTE: select에 실제 인자로 넣을 read_set

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -30,13 +30,13 @@ int		main(int argc, char* argv[], char* envp[])
 		}
 	}
 
-	// try
-	// {
-	// 	manager.runServer();
-	// }
-	// catch (std::exception& e)
-	// {
-	// 	manager.exitServer(e.what());
-	// }
+	try
+	{
+		manager.runServer();
+	}
+	catch (std::exception& e)
+	{
+		manager.exitServer(e.what());
+	}
 	return (0);
 }


### PR DESCRIPTION
## **WHAT?**
각 서버가 실행되기 전 설정 파일을 파싱하고 서버를 만드는 로직(소켓 설정)까지 우선 완성해두려고 하는데, 
설정 파일 파싱하는 부분은 일단 주석 처리해두었고, 그 외 부분은 컴파일은 동작하게 작성해두었음.

```c++
void	ServerManager::createServer(const std::string& configuration_file_path, char** envp);
Server::Server(ServerManager* server_manager, const std::string& server_block, std::vector<std::string>& location_blocks, Config* config);
```
위의 두 함수를 제외하고는 나머지는 그냥 빈 코드블럭만 만들어서 컴파일만 동작하게 만들어 두었고, 

내가 임의로 설정했거나 잘 모르겠거나 의논해보고 싶은 부분은 앵커로 남겨놓았음 

## **TESTING**
임시코드라서 테스트를 진행하지 못했음.
우선 작성된 코드들은 에러를 던지지 않는 것으로보아 정상적으로 동작한다고만 생각했음.

## ISSUE and REFERENCE
#31 