### PR TITLE
Feat/connection class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ $(NAME)		:	$(SRCS)
 
 
 # yunslee가 쓰는 소스코드모음
-# clang++ -g gnl/get_next_line_bonus.cpp gnl/get_next_line_utils_bonus.cpp   srcs/main.cpp  srcs/ServerManager.cpp  srcs/Server.cpp  srcs/Config.cpp  srcs/Location.cpp   srcs/Connection.cpp     srcs/ConfigFile/ConfigFile.cpp   srcs/ConfigFile/ConfigFiles.cpp   srcs/Path/Path.cpp   srcs/ServerConfigIdx/ServerConfigIdx.cpp   srcs/Utils/utils.cpp srcs/Response.cpp
+# clang++ -g gnl/get_next_line_bonus.cpp gnl/get_next_line_utils_bonus.cpp   srcs/main.cpp  srcs/ServerManager.cpp  srcs/Server.cpp  srcs/Config.cpp  srcs/Location.cpp   srcs/Connection.cpp     srcs/ConfigFile/ConfigFile.cpp   srcs/ConfigFile/ConfigFiles.cpp   srcs/Path/Path.cpp   srcs/ServerConfigIdx/ServerConfigIdx.cpp   srcs/Utils/utils.cpp srcs/Response.cpp srcs/Request.cpp

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SRCS	=	gnl/get_next_line_bonus.cpp gnl/get_next_line_utils_bonus.cpp \
 			srcs/Config.cpp\
 			srcs/Location.cpp \
 			srcs/Connection.cpp \
+			srcs/Response.cpp \
 			\
 			srcs/ConfigFile/ConfigFile.cpp \
 			srcs/ConfigFile/ConfigFiles.cpp \
@@ -49,4 +50,4 @@ $(NAME)		:	$(SRCS)
 
 
 # yunslee가 쓰는 소스코드모음
-# clang++ -g gnl/get_next_line_bonus.cpp gnl/get_next_line_utils_bonus.cpp   srcs/main.cpp  srcs/ServerManager.cpp  srcs/Server.cpp  srcs/Config.cpp  srcs/Location.cpp   srcs/Connection.cpp     srcs/ConfigFile/ConfigFile.cpp   srcs/ConfigFile/ConfigFiles.cpp   srcs/Path/Path.cpp   srcs/ServerConfigIdx/ServerConfigIdx.cpp   srcs/Utils/utils.cpp
+# clang++ -g gnl/get_next_line_bonus.cpp gnl/get_next_line_utils_bonus.cpp   srcs/main.cpp  srcs/ServerManager.cpp  srcs/Server.cpp  srcs/Config.cpp  srcs/Location.cpp   srcs/Connection.cpp     srcs/ConfigFile/ConfigFile.cpp   srcs/ConfigFile/ConfigFiles.cpp   srcs/Path/Path.cpp   srcs/ServerConfigIdx/ServerConfigIdx.cpp   srcs/Utils/utils.cpp srcs/Response.cpp

--- a/autoindex_example.html
+++ b/autoindex_example.html
@@ -1,0 +1,8 @@
+<html>
+<head><title>Index of //gnl</title></head><body>
+<h1>Index of //gnl</h1><hr><pre>
+<a href="http://localhost:8000/get_next_line_bonus.cpp">get_next_line_bonus.cpp</a><br>
+<a href="http://localhost:8000/get_next_line_bonus.hpp">get_next_line_bonus.hpp</a><br>
+<a href="http://localhost:8000/get_next_line_utils_bonus.cpp">get_next_line_utils_bonus.cpp</a><br>
+</pre></hr></body>
+</html>

--- a/error_example.html
+++ b/error_example.html
@@ -1,0 +1,1 @@
+<html><head><title>404 Not Found</title></head><body bgcolor="white"><center> 					<h1>404 Not Found</h1></center><hr><center>YKK_Webserver</center></body></html>

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -18,6 +18,12 @@ Connection::Connection(void)
 	gettimeofday(&(this->m_last_request_at), NULL);
 }
 
+Connection::~Connection(void)
+{
+	// TODO mRequest에 대한 처리가 필요함.
+}
+
+
 const int&				Connection::get_m_fd(void) const{return (this->m_fd);}
 
 const struct timeval&	Connection::get_m_last_request_at(void) const{	return (this->m_last_request_at);}

--- a/srcs/Connection.hpp
+++ b/srcs/Connection.hpp
@@ -14,6 +14,11 @@ class Connection
 public:
 	Connection(int client_fd, std::string client_ip, int client_port);
 	Connection(void);
+	
+	// std::map<int, Connection>	m_connections;
+	// TODO map에서 컨낵션이 끊어졌을 때, *mRequest free 해줘야함(not NULL 일 때,)
+	// TODO map에서 컨낵션이 끊어지지는 않았으나(keep-alive), 한번의 요청을 처리해줫을 때( ePhase== COMPLETE), delete 후 NULL값 할당.
+	virtual ~Connection(void);
 
 	const int&				get_m_fd(void) const;
 	const struct timeval&	get_m_last_request_at(void) const;

--- a/srcs/Define.hpp
+++ b/srcs/Define.hpp
@@ -4,7 +4,7 @@
 #define DEFAULT_CONFIG_FILE_PATH "default.config"
 #define BUFFER_SIZE 1024
 #define INIT_FD_MAX 512
-#define KEEP_ALIVE_LIMIT 10 // TODO 갱신처리 안됬음!
+#define KEEP_ALIVE_LIMIT 5 // TODO 갱신처리 안됬음!
 #define SELECT_TIMEOUT_SEC 3
 #define SELECT_TIMEOUT_USEC 0
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -1,0 +1,80 @@
+#include "Response.hpp"
+
+Response::Response()
+{
+	this->init_status_map();
+}
+
+Response::~Response()
+{
+	
+}
+
+Response::Response(Connection* connection, int status_code, std::string body)
+	: m_connection(connection), m_status_code(status_code), m_body(body)
+{
+	this->init_status_map();
+	if (this->m_status_map.find(status_code) == this->m_status_map.end())
+	{
+		this->m_status_description = this->m_status_map[status_code];
+		this->addHeader(ft::itoa(this->m_status_code), this->m_status_description);
+	}
+	else
+	{
+		std::cout << "There is no status " << status_code << " code" << std::endl;
+		// FIXME try catch로 throw를 던져야할 것 같음.
+	}
+	this->m_body = this->makeErrorPage(m_status_code);
+}
+
+const Connection*								Response::get_m_connection(void) const{return (this->m_connection);}
+
+const int&										Response::get_m_status_code(void) const{return (this->m_status_code);}
+
+const std::string&								Response::get_m_status_description(void) const{return (this->m_status_description);}
+
+const std::map<std::string, std::string>		Response::get_m_headers(void) const{return (this->m_headers);}
+
+const enum TransferType&						Response::get_m_transfer_type(void) const{	return (this->m_transfer_type);}
+
+const std::string&								Response::get_m_body(void) const{	return (this->m_body);}
+
+// const std::string&								Response::get_m_firstline(void) const { return (this->m_firstline);}
+
+void											Response::addHeader(std::string header_key, std::string header_value)
+{
+	this->m_headers[header_key] = header_value;
+}
+
+const std::string								Response::getResponse(void)
+{
+	std::string all;
+	
+	std::string firstline;
+	firstline += "HTTP/1.1 "; firstline += ft::itoa(m_status_code); firstline += " "; firstline += this->m_status_map[m_status_code]; firstline += "\r\n";
+	all += "\r\n";
+	std::map<std::string, std::string>::iterator it = m_headers.begin();
+	while(it != m_headers.end())
+	{
+		all += it->first;
+		all += ": ";
+		all += it->second;
+		all += "\r\n";
+	}
+	all += "\r\n";
+	all += this->m_body;
+	return (all);
+}
+
+std::string										Response::makeErrorPage(int status_code)
+{
+	std::string errorpage;
+	errorpage = "<html><head><title>STATUS_CODE STATUS_DESCRIPTION</title></head><body bgcolor=\"white\"><center> \
+					<h1>STATUS_CODE STATUS_DESCRIPTION</h1></center><hr><center>YKK_Webserver</center></body></html>";
+	
+	std::string status_str = ft::itoa(status_code);
+	ft::ReplaceAll(errorpage, "STATUS_CODE", status_str);
+	ft::ReplaceAll(errorpage, "STATUS_DESCRIPTION", this->m_status_description);
+	return (errorpage);
+}
+

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -17,7 +17,7 @@ Response::Response(Connection* connection, int status_code, std::string body)
 	if (this->m_status_map.find(status_code) == this->m_status_map.end())
 	{
 		this->m_status_description = this->m_status_map[status_code];
-		this->addHeader(ft::itoa(this->m_status_code), this->m_status_description);
+		this->addHeader(std::to_string(this->m_status_code), this->m_status_description);
 	}
 	else
 	{
@@ -51,7 +51,7 @@ const std::string								Response::getResponse(void)
 	std::string all;
 	
 	std::string firstline;
-	firstline += "HTTP/1.1 "; firstline += ft::itoa(m_status_code); firstline += " "; firstline += this->m_status_map[m_status_code]; firstline += "\r\n";
+	firstline += "HTTP/1.1 "; firstline += std::to_string(m_status_code); firstline += " "; firstline += this->m_status_map[m_status_code]; firstline += "\r\n";
 	all += "\r\n";
 	std::map<std::string, std::string>::iterator it = m_headers.begin();
 	while(it != m_headers.end())
@@ -72,9 +72,9 @@ std::string										Response::makeErrorPage(int status_code)
 	errorpage = "<html><head><title>STATUS_CODE STATUS_DESCRIPTION</title></head><body bgcolor=\"white\"><center> \
 					<h1>STATUS_CODE STATUS_DESCRIPTION</h1></center><hr><center>YKK_Webserver</center></body></html>";
 	
-	std::string status_str = ft::itoa(status_code);
+	std::string status_str = std::to_string(status_code);
 	ft::ReplaceAll(errorpage, "STATUS_CODE", status_str);
-	ft::ReplaceAll(errorpage, "STATUS_DESCRIPTION", this->m_status_description);
+	ft::ReplaceAll(errorpage, "STATUS_DESCRIPTION", Response::m_status_map[status_code]);
 	return (errorpage);
 }
 

--- a/srcs/Response.hpp
+++ b/srcs/Response.hpp
@@ -28,11 +28,11 @@ public:
 	const std::string&								get_m_body(void) const;
 
 	void											addHeader(std::string header_key, std::string header_value);
-	const std::string								getResponse(void);
+	const std::string									getResponse(void);
 
 	// ANCHOR yunslee
-	std::string										makeErrorPage(int status_code);
-	
+	static std::string								makeErrorPage(int status_code);
+	static std::map<int, std::string >				m_status_map;
 	static void				init_status_map(void)
 	{
 		m_status_map[100] = "Continue";
@@ -92,7 +92,6 @@ public:
 	}
 
 private:
-	static std::map<int, std::string >				m_status_map;
 	// std::string										m_firstline; 사용하지 않아도 될 것 같음.
 	Connection*										m_connection;
 	int												m_status_code;

--- a/srcs/Response.hpp
+++ b/srcs/Response.hpp
@@ -5,37 +5,103 @@
 
 #include <string>
 #include <map>
-#include "Connection.hpp"
+// #include "Connection.hpp"
+#include "Utils/utils.hpp"
+
+class Connection;
+
+enum TransferType								{ GENERAL, CHUNKED };
 
 class Response
 {
 public:
-	Response(Connection* connection, int status_code, std::string body="");
+	Response();
+	virtual ~Response();
+	Response(Connection* connection, int status_code, std::string body);
 
 	const Connection*								get_m_connection(void) const;
 	const int&										get_m_status_code(void) const;
 	const std::string&								get_m_status_description(void) const;
+	const std::string&								get_m_firstline(void) const;
 	const std::map<std::string, std::string>		get_m_headers(void) const;
 	const enum TransferType&						get_m_transfer_type(void) const;
-	const std::string&								get_m_content(void) const;
+	const std::string&								get_m_body(void) const;
 
 	void											addHeader(std::string header_key, std::string header_value);
-	char*											c_str(void);
-	std::map<int, std::vector<std::string> >		make_status(void);
+	const std::string								getResponse(void);
 
+	// ANCHOR yunslee
+	std::string										makeErrorPage(int status_code);
+	
+	static void				init_status_map(void)
+	{
+		m_status_map[100] = "Continue";
+		m_status_map[101] = "Switching Protocols";
+		m_status_map[103] = "Early Hints";
+		m_status_map[200] = "OK";
+		m_status_map[201] = "Created";
+		m_status_map[202] = "Accepted";
+		m_status_map[203] = "Non-Authoritative Information";
+		m_status_map[204] = "No Content";
+		m_status_map[205] = "Reset Content";
+		m_status_map[206] = "Partial Content";
+		m_status_map[301] = "Moved Permanently";
+		m_status_map[300] = "Multiple Choices";
+		m_status_map[303] = "See Other";
+		m_status_map[302] = "Found";
+		m_status_map[307] = "Temporary Redirect";
+		m_status_map[304] = "Not Modified";
+		m_status_map[400] = "Bad Request";
+		m_status_map[308] = "Permanent Redirect";
+		m_status_map[402] = "Payment Required";
+		m_status_map[401] = "Unauthorized";
+		m_status_map[404] = "Not Found";
+		m_status_map[403] = "Forbidden";
+		m_status_map[406] = "Not Acceptable";
+		m_status_map[405] = "Method Not Allowed";
+		m_status_map[408] = "Request Timeout";
+		m_status_map[407] = "Proxy Authentication Required";
+		m_status_map[410] = "Gone";
+		m_status_map[409] = "Conflict";
+		m_status_map[412] = "Precondition Failed";
+		m_status_map[411] = "Length Required";
+		m_status_map[414] = "URI Too Long";
+		m_status_map[413] = "Payload Too Large";
+		m_status_map[416] = "Range Not Satisfiable";
+		m_status_map[415] = "Unsupported Media Type";
+		m_status_map[418] = "I'm a teapot";
+		m_status_map[417] = "Expectation Failed";
+		m_status_map[425] = "Too Early";
+		m_status_map[422] = "Unprocessable Entity";
+		m_status_map[428] = "Precondition Required";
+		m_status_map[426] = "Upgrade Required";
+		m_status_map[431] = "Request Header Fields Too Large";
+		m_status_map[429] = "Too Many Requests";
+		m_status_map[500] = "Internal Server Error";
+		m_status_map[451] = "Unavailable For Legal Reasons";
+		m_status_map[502] = "Bad Gateway";
+		m_status_map[501] = "Not Implemented";
+		m_status_map[504] = "Gateway Timeout";
+		m_status_map[503] = "Service Unavailable";
+		m_status_map[506] = "Variant Also Negotiates";
+		m_status_map[505] = "HTTP Version Not Supported";
+		m_status_map[508] = "Loop Detected";
+		m_status_map[507] = "Insufficient Storage";
+		m_status_map[511] = "Network Authentication Required";
+		m_status_map[510] = "Not Extended";
+	}
 
 private:
-	enum TransferType								{ GENERAL, CHUNKED };
-
-	static std::map<int, std::vector<std::string> >	status;
+	static std::map<int, std::string >				m_status_map;
+	// std::string										m_firstline; 사용하지 않아도 될 것 같음.
 	Connection*										m_connection;
 	int												m_status_code;
 	std::string										m_status_description;
 	std::map<std::string, std::string>				m_headers;
 	enum TransferType								m_transfer_type;
-	std::string										m_content;
-
+	std::string										m_body;
+	
+	
 };
-
 
 #endif

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -88,9 +88,9 @@ int 	Server::SetSocket(std::string ip, uint16_t port)
 	sockaddr_in sockaddr;
 	ft::memset((sockaddr_in *)&sockaddr, 0, sizeof(sockaddr_in));
 	sockaddr.sin_family = AF_INET;
-	// sockaddr.sin_addr.s_addr = inet_addr(ip.c_str()); // REVIEW 위 아래 어떤 것으로 쓸지
-	sockaddr.sin_addr.s_addr = INADDR_ANY;
-	sockaddr.sin_port = htons(this->mport); // htons is necessary to convert a number to
+	sockaddr.sin_addr.s_addr = ft::ft_inet_addr(ip.c_str()); // REVIEW 위 아래 어떤 것으로 쓸지
+	// sockaddr.sin_addr.s_addr = INADDR_ANY;
+	sockaddr.sin_port = ft::ft_htons(this->mport); // htons is necessary to convert a number to
 
 	int opt = 1; // 소켓을 재사용하려면 희한하게도 1로 설정해야한다.
 	setsockopt(this->msocket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -26,6 +26,7 @@
 using namespace std;
 
 class ServerManager;
+class Request;
 
 class LocationPath
 {
@@ -79,21 +80,21 @@ public:
 	int							getUnuseConnectionFd();
 	void						closeConnection(int client_fd);
 
-
 	bool						parseStartLine(Connection& connection);
 	bool						parseHeader(Connection& connection);
 	bool						parseBody(Connection& connection);
 
+	bool						isRequestHasBody(Request *);
 	bool						hasRequest(const Connection& connection);
 	bool						runRecvAndSolve(Connection& connection);
 	// bool						hasExecuteWork(Connection& connection);
 	// bool						runExecute(Connection& connection);
-	// bool						hasSendWork(Connection& connection);
-	// bool						runSend(Connection& connection);
+	bool						hasSendWork(Connection& connection);
+	bool						runSend(Connection& connection);
 
 	void						run(void);
 	// void						solveRequest(Connection& connection, const Request& request);
-	// void						executeAutoindex(Connection& connection, const Request& request);
+	void						executeAutoindex(Connection& connection, const Request& request);
 	// void						executeGet(Connection& connection, const Request& request);
 	// void						executeHead(Connection& connection, const Request& request);
 	// void						executePost(Connection& connection, const Request& request);
@@ -105,6 +106,13 @@ public:
 	// void						createResponse(Connection& connection, int status, headers_t headers = headers_t(), std::string body = "");
 
 	const int&					get_m_fd(void) const;
+
+
+	class ClientServerClose : public std::exception
+	{
+		public:
+			const char* what() const throw();
+	};
 
 public :
 	ServerManager*				m_manager;

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -281,7 +281,7 @@ int ServerManager::SetServers()
 	for (size_t i = 0; i < this->m_servers.size(); i++)
 	{
 		Server &server = this->m_servers[i];
-		server.SetSocket("INADDR_ANY", server.mport);
+		server.SetSocket("0.0.0.0", server.mport);
 		server.m_manager = this; 
 		server.m_connections[server.msocket] = Connection(server.msocket, "INADDR_ANY", server.mport);
 	}

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -151,10 +151,11 @@ bool		ServerManager::fdIsset(int fd, SetType fdset)
 		{
 			return (true);
 		}
-	  else
-	  {
+		else
+		{
 		  return (false);
-	  }
+		}
+	}
 }
 
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -45,6 +45,7 @@ void		ServerManager::runServer(void)
 		resetMaxFd();
 		cout << "m_max_fd: " << m_max_fd << endl;
 		int	cnt = select(m_max_fd + 1, &m_read_copy_set, &m_write_copy_set, NULL, &timeout);
+		cout << "cnt : " << cnt << endl;
 		if (cnt < 0)
 		{
 			std::cout << "Select error\n";
@@ -57,6 +58,13 @@ void		ServerManager::runServer(void)
 		}
 		else if (cnt > 0)
 		{
+			std::vector<int> read_set;
+			read_set = ft::getVector_changedFD(&m_read_copy_set, m_max_fd + 1);
+			std::vector<int> write_set;
+			write_set = ft::getVector_changedFD(&m_write_copy_set, m_max_fd + 1);
+
+			// cout << "read_set size: " << read_set.size() << endl;
+			// cout << "write_set size: " << write_set.size() << endl;
 			std::cout << "Received connection\n";
 		}
 
@@ -73,6 +81,8 @@ void		ServerManager::runServer(void)
 	}
 	exitServer("server exited.\n");
 }
+
+const int&	ServerManager::get_m_max_fd(void) const{return (this->m_max_fd);}
 
 void		ServerManager::set_m_max_fd(const int& fd)
 {
@@ -126,11 +136,13 @@ bool		ServerManager::fdIsset(int fd, SetType fdset)
 {
 	if (fdset == WRITE_SET)
 	{
-		return (FD_ISSET(fd, &m_write_copy_set));
+		if (FD_ISSET(fd, &m_write_copy_set))
+			return (true);
 	}
 	else if (fdset == READ_SET)
 	{
-		return (FD_ISSET(fd, &m_read_copy_set));
+		if (FD_ISSET(fd, &m_read_copy_set)) 
+			return (true);
 	}
 	else
 	{
@@ -324,6 +336,7 @@ void	ServerManager::closeOldConnection(std::vector<Server>::iterator server_it)
 		{
 			cout << "closeOldConnection: " << it2->second.get_m_fd() << endl;
 			close (it2->second.get_m_fd());
+			FD_CLR(it2->second.get_m_fd(), &(server_it->m_manager->GetWriteSet()));
 			FD_CLR(it2->second.get_m_fd(), &(server_it->m_manager->GetReadSet()));
 			server_it->m_connections.erase(it2);
 			return ;

--- a/srcs/ServerManager.hpp
+++ b/srcs/ServerManager.hpp
@@ -18,6 +18,7 @@ class Server;
 #include "Utils/utils.hpp"
 #include "Path/Path.hpp"
 #include "ConfigFile/ConfigFiles.hpp"
+#include "Response.hpp"
 
 using namespace std;
 

--- a/srcs/Utils/utils.cpp
+++ b/srcs/Utils/utils.cpp
@@ -46,44 +46,44 @@ std::string ft::ReplaceAll(std::string &str, const std::string& from, const std:
 }
 
 // FIXME 최종적으로 안쓰면 지우기.
-// static int	atoi_while(const char *str, int i, int sign)
-// {
-// 	unsigned long long int	sum;
+static int	atoi_while(const char *str, int i, int sign)
+{
+	unsigned long long int	sum;
 
-// 	sum = 0;
-// 	while (str[i] >= 48 && str[i] <= 57)
-// 	{
-// 		sum *= 10;
-// 		sum += str[i] - 48;
-// 		i++;
-// 	}
-// 	if (sum > LLONG_MAX && sign == -1)
-// 		return (0);
-// 	if (sum > LLONG_MAX && sign == 1)
-// 		return (-1);
-// 	return ((int)sum);
-// }
+	sum = 0;
+	while (str[i] >= 48 && str[i] <= 57)
+	{
+		sum *= 10;
+		sum += str[i] - 48;
+		i++;
+	}
+	if (sum > LLONG_MAX && sign == -1)
+		return (0);
+	if (sum > LLONG_MAX && sign == 1)
+		return (-1);
+	return ((int)sum);
+}
 
-// int			ft::atoi(const char *str)
-// {
-// 	int i;
-// 	int sign;
+int			ft::atoi(const char *str)
+{
+	int i;
+	int sign;
 
-// 	sign = 1;
-// 	i = 0;
-// 	while (str[i] == 32 || (str[i] >= 9 && str[i] <= 13))
-// 		i++;
-// 	if (str[i] == '-')
-// 	{
-// 		sign *= -1;
-// 		i++;
-// 	}
-// 	else if (str[i] == '+')
-// 		i++;
-// 	if (!(str[i] >= 48 && str[i] <= 57))
-// 		return (0);
-// 	return (sign * atoi_while(str, i, sign));
-// }
+	sign = 1;
+	i = 0;
+	while (str[i] == 32 || (str[i] >= 9 && str[i] <= 13))
+		i++;
+	if (str[i] == '-')
+	{
+		sign *= -1;
+		i++;
+	}
+	else if (str[i] == '+')
+		i++;
+	if (!(str[i] >= 48 && str[i] <= 57))
+		return (0);
+	return (sign * atoi_while(str, i, sign));
+}
 
 static int		ft_itoa_len(int v)
 {
@@ -176,3 +176,61 @@ bool ft::isDirPath(const std::string &path)
  * @param  {uint16_t} code : 상태 코드
  * @return {std::string}   : 상태 코드에 따른 상태 메세지 문자열
  */
+
+
+u_int32_t ft::ft_htonl(u_int32_t addr)
+{
+	int num = 1;
+	bool little_endian = 0;
+	if (*(char *)&num == 1)
+	{
+		little_endian = true;
+		u_int32_t res = (((((unsigned long)(addr) & 0xFF)) << 24) | \
+						((((unsigned long)(addr) & 0xFF00)) << 8) | \
+						((((unsigned long)(addr) & 0xFF0000)) >> 8) | \
+						((((unsigned long)(addr) & 0xFF000000)) >> 24));
+		return (res);
+	}
+	else
+	{
+		little_endian = false;
+		return ((u_int32_t)addr);
+	}
+}
+
+
+// NOTE 정상적으로 들어왔을 때를 가정함. (.... | 2.3..4.)
+in_addr_t	 ft::ft_inet_addr(const char *ip_addr)
+{
+	if (ip_addr == NULL)
+		return (0);
+	std::string ip_string; ip_string.assign(ip_addr);
+	std::vector<std::string> ip_dot_divid;
+	ft::split_vector(ip_dot_divid, ip_string, ".");
+	if (ip_dot_divid.size() != 4)
+		return (0);
+	u_int32_t ip_host = 0;
+	ip_host += ft::atoi(ip_dot_divid[0].c_str()) << 24;
+	ip_host += ft::atoi(ip_dot_divid[1].c_str()) << 16;
+	ip_host += ft::atoi(ip_dot_divid[2].c_str()) << 8;
+	ip_host += ft::atoi(ip_dot_divid[3].c_str());
+	u_int32_t ip_network = ft_htonl(ip_host);
+	return (ip_network);
+}
+
+u_int16_t ft::ft_htons(u_int16_t addr)
+{
+	int num = 1;
+	bool little_endian = 0;
+	if (*(char *)&num == 1)
+	{
+		little_endian = true;
+		u_int16_t res =((((u_int16_t)(addr) & 0xFF)) << 8) | ((((u_int16_t)(addr) & 0xFF00)) >> 8);
+		return (res);
+	}
+	else
+	{
+		little_endian = false;
+		return ((u_int16_t)addr);
+	}
+}

--- a/srcs/Utils/utils.cpp
+++ b/srcs/Utils/utils.cpp
@@ -235,7 +235,7 @@ u_int16_t ft::ft_htons(u_int16_t addr)
 	}
 }
 
-
+// NOTE nginx에서 autoindex로 나오는 페이지의 html을 베껴썼다.
 std::string ft::makeAutoindexHTML(std::string url)
 {
 	DIR *dir;
@@ -251,23 +251,56 @@ std::string ft::makeAutoindexHTML(std::string url)
 	// url = this->_request.getHeaderValue("Host") + this->_request.getStartLine().path;
 	dir = opendir(root_string.c_str());
 	res += "<html>\n";
-	res += "<head><title>Index of /</title></head>";
+	res += "<head><title>Index of /"; res+= url; res+= "</title></head>";
 	res += "<body>\n";
-	res += "<h1>Directory listing</h1>\n";
+	res += "<h1>Index of /"; res+= url; res+= "</h1><hr><pre>\n";
 	while ((curr = readdir(dir)) != NULL)
 	{
 		if (curr->d_name[0] != '.')
 		{
 			res += "<a href=\"http://";
-			res += "localhost:8080/";
-			res += curr->d_name;
-			res += "\">";
-			res += curr->d_name;
-			res += "</a><br>\n";
+			res += "localhost:8000/"; res += curr->d_name; res += "\">";
+			res += curr->d_name; res += "</a><br>\n";
 		}
 		// cout << "1" << endl;
 	}
 	closedir(dir);
-	res += "</body>\n</html>\n";
+	res += "</pre></hr></body>\n</html>\n";
 	return (res);
+}
+
+
+std::vector<int> ft::getVector_changedFD(fd_set *fdset, size_t fdset_size)
+{
+	std::vector<int> ret;
+	for (size_t i = 0; i < fdset_size; i++)
+	{
+		if (FD_ISSET(i, fdset) > 0)
+		{
+			ret.push_back((int)i);
+			std::cout << i << " ";
+		}
+	}
+	if (ret.size() == 0)
+		std::cout << "empty | size: 0" << std::endl;
+	else
+		std::cout << "| size: " << ret.size() << std::endl;
+	return (ret);
+}
+
+
+std::string ft::getHTTPTimeFormat(time_t time)
+{
+	char s[150];
+	struct tm *tm_time = std::gmtime(&time);
+
+	strftime(s, sizeof(s), "%a, %d %b %Y %T GMT", tm_time);
+    return (s);
+}
+
+std::string ft::getCurrentTime()
+{
+	struct timeval time;
+	gettimeofday(&time, NULL);
+	return (getHTTPTimeFormat(time.tv_sec));
 }

--- a/srcs/Utils/utils.cpp
+++ b/srcs/Utils/utils.cpp
@@ -33,3 +33,146 @@ void ft::split_vector(std::vector<std::string> &vec, const std::string& str, con
 		before = after + 1;
 	}
 }
+
+std::string ft::ReplaceAll(std::string &str, const std::string& from, const std::string& to)
+{
+    size_t start_pos = 0; //string처음부터 검사
+    while((start_pos = str.find(from, start_pos)) != std::string::npos)  //from을 찾을 수 없을 때까지
+    {
+        str.replace(start_pos, from.length(), to);
+        start_pos += to.length(); // 중복검사를 피하고 from.length() > to.length()인 경우를 위해서
+    }
+    return str;
+}
+
+// FIXME 최종적으로 안쓰면 지우기.
+// static int	atoi_while(const char *str, int i, int sign)
+// {
+// 	unsigned long long int	sum;
+
+// 	sum = 0;
+// 	while (str[i] >= 48 && str[i] <= 57)
+// 	{
+// 		sum *= 10;
+// 		sum += str[i] - 48;
+// 		i++;
+// 	}
+// 	if (sum > LLONG_MAX && sign == -1)
+// 		return (0);
+// 	if (sum > LLONG_MAX && sign == 1)
+// 		return (-1);
+// 	return ((int)sum);
+// }
+
+// int			ft::atoi(const char *str)
+// {
+// 	int i;
+// 	int sign;
+
+// 	sign = 1;
+// 	i = 0;
+// 	while (str[i] == 32 || (str[i] >= 9 && str[i] <= 13))
+// 		i++;
+// 	if (str[i] == '-')
+// 	{
+// 		sign *= -1;
+// 		i++;
+// 	}
+// 	else if (str[i] == '+')
+// 		i++;
+// 	if (!(str[i] >= 48 && str[i] <= 57))
+// 		return (0);
+// 	return (sign * atoi_while(str, i, sign));
+// }
+
+static int		ft_itoa_len(int v)
+{
+	int i;
+
+	i = 0;
+	if (v == 0)
+		return (1);
+	if (v < 0)
+		i = 1;
+	while (v != 0)
+	{
+		v /= 10;
+		i++;
+	}
+	return (i);
+}
+
+char	*ft::itoa(int n)
+{
+	char	*itoa;
+	int		itoa_len;
+	int		i;
+	int		temp;
+
+	i = 1;
+	itoa_len = ft_itoa_len(n);
+	if (NULL == (itoa = (char *)malloc(sizeof(char) * (itoa_len + 1))))
+		return (NULL);
+	if (n < 0)
+		itoa[0] = '-';
+	else if (n == 0)
+		itoa[0] = '0';
+	itoa[itoa_len] = '\0';
+	while (n != 0)
+	{
+		temp = n % 10;
+		if (temp < 0)
+			temp *= -1;
+		itoa[itoa_len - i] = temp + '0';
+		n /= 10;
+		i++;
+	}
+	return (itoa);
+}
+
+
+
+/**
+ * isFilePath : path가 file path인지 체크하는 함수
+ * @param  {std::string} path : 경로
+ * @return {bool}             : 1 : 파일 경로, 0 : 파일 경로 x
+ */
+bool ft::isFilePath(const std::string &path)
+{
+	struct stat info;
+
+	if (stat(path.c_str(), &info) == 0)
+	{
+		if (S_ISREG(info.st_mode))
+			return 1;
+		else
+			return 0;
+	}
+	else
+		return 0;
+}
+
+/**
+ * isDirPath : path가 directory path인지 체크하는 함수
+ * @param  {std::string} path : 경로
+ * @return {bool}             : 1 : 폴더 경로, 0 : 폴더 경로 x
+ */
+bool ft::isDirPath(const std::string &path)
+{
+	struct stat info;
+
+	if (stat(path.c_str(), &info) == 0)
+	{
+		if (S_ISDIR(info.st_mode))
+			return 1;
+		else
+			return 0;
+	}
+	else
+		return 0;
+}
+/**
+ * getStatusStr : 상태 코드에 따른 메세지 문자열을 구해주는 함수
+ * @param  {uint16_t} code : 상태 코드
+ * @return {std::string}   : 상태 코드에 따른 상태 메세지 문자열
+ */

--- a/srcs/Utils/utils.hpp
+++ b/srcs/Utils/utils.hpp
@@ -3,12 +3,20 @@
 
 #include <iostream>
 #include <vector>
+#include <sys/stat.h>
+// #include <limits.h> // FIXME atoi 쓸꺼면 필요함.
 
 namespace ft
 {
-	void	testNameSpace(void);
-	void	*memset(void *b, int c, size_t len);
-	void	split_vector(std::vector<std::string> &vec, const std::string& str, const char *delim);
+	void			testNameSpace(void);
+	void*			memset(void *b, int c, size_t len);
+	void			split_vector(std::vector<std::string> &vec, const std::string& str, const char *delim);
+	std::string		ReplaceAll(std::string &str, const std::string& from, const std::string& to);
+	// int				atoi(const char *str);
+	char*			itoa(int n);
+
+	bool isFilePath(const std::string &path);
+	bool isDirPath(const std::string &path);
 }
 
 #endif

--- a/srcs/Utils/utils.hpp
+++ b/srcs/Utils/utils.hpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <vector>
 #include <sys/stat.h>
-// #include <limits.h> // FIXME atoi 쓸꺼면 필요함.
+#include <limits.h> // FIXME atoi 쓸꺼면 필요함.
 
 namespace ft
 {
@@ -14,9 +14,13 @@ namespace ft
 	std::string		ReplaceAll(std::string &str, const std::string& from, const std::string& to);
 	// int				atoi(const char *str);
 	char*			itoa(int n);
+	int				atoi(const char *str);
 
 	bool isFilePath(const std::string &path);
 	bool isDirPath(const std::string &path);
+	u_int32_t ft_htonl(u_int32_t ip_addr);
+	u_int16_t ft_htons(u_int16_t port);
+	in_addr_t ft_inet_addr(const char * ip_address);
 }
 
 #endif

--- a/srcs/Utils/utils.hpp
+++ b/srcs/Utils/utils.hpp
@@ -4,9 +4,10 @@
 #include <iostream>
 #include <vector>
 #include <sys/stat.h>
-#include <limits.h> // FIXME atoi 쓸꺼면 필요함.
+#include <limits.h> // FIXME atoi 쓸꺼면 필요함, stoi => c++11
 #include <dirent.h>
 #include <unistd.h>
+#include <sys/time.h>
 
 namespace ft
 {
@@ -15,12 +16,17 @@ namespace ft
 	void			split_vector(std::vector<std::string> &vec, const std::string& str, const char *delim);
 	std::string		ReplaceAll(std::string &str, const std::string& from, const std::string& to);
 	// int				atoi(const char *str);
-	char*			itoa(int n);
+	char*			itoa(int n); // FIXME std::to_string으로 대체가능 <string>
 	int				atoi(const char *str);
 
 	bool isFilePath(const std::string &path);
 	bool isDirPath(const std::string &path);
 	std::string makeAutoindexHTML(std::string root);
+
+	std::string getHTTPTimeFormat(time_t time);
+	std::string getCurrentTime();
+
+	std::vector<int> getVector_changedFD(fd_set *fdset, size_t fdset_size);
 
 	// 서브젝트 허용 매크로함수로 변경됨.
 	u_int32_t ft_htonl(u_int32_t ip_addr);

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,9 +1,11 @@
 #include "ServerManager.hpp"
 
 // bool	g_live; // REVIEW: g_live 를 쓰길래, 전역변수 느낌인 것같아서 여기에 선언함.
+std::map<int, std::string> Response::m_status_map; // NOTE static 변수도 전역변수라도 한번 선언을 해줘야함.
 
 int		main(int argc, char* argv[], char* envp[])
 {
+	Response::init_status_map();
 	ServerManager	manager;
 	// manager.openLog();
 	if (argc > 2)
@@ -28,7 +30,7 @@ int		main(int argc, char* argv[], char* envp[])
 			manager.exitServer(e.what());
 		}
 	}
-
+	
 	try
 	{
 		manager.runServer();


### PR DESCRIPTION
## Squash로 5개의 커밋 메세지를 아래에 기록함.

기존에 작업하던 내용과 병합
Fix: postman에서 Client 연결을 종료하는 경우, 정상동작하도록 수정

postman에서 요청을 보내는 중에 요청하기를 그만 둘 때, 서버가 종료되지않고 잘 동작하도록 함.

코딩실수를 한 부분도 있고, throw를 날리는 것을 hasSendWork() 함수에서 임시방편으로 read()함으로써 문제릃 해결하고 있다.

TODO: read 함수를 하는 것은 request 함수 내부에서 해야하므로, 해당 에러처리는 자리가 옮겨질 것으로 보인다.


Fix: 코딩실수

이전에 수정하는 과정에서  FD_CLR하는 것을 지워버림
Fix: autoindex추가, requestparsing해결방법고안,  utils함수추가, keep-alive 기능 일단삭제

1. ft::makeAutoindexHTML()를 통해, 인자에 경로만 잘 넣어주면, autoindex.html으로 쓸 수 있는 std::string 을 반환하는 함수를 만듦
2. requestParsing에서 select함수 한번 지나갈때마다, read함수를 한번 실행하는 문제에 대해서, 해결방법을 모색해 보았음.
주석처리 되었던 함수(isRequestHasBody)를 Method에 따라서 반환함으로써 이용해보았음.(모든 경우를 커버하는지는 확인해봐야할 듯)
3. utils.cpp에 여러가지 함수를 추가함.  
  3.1 Date 헤더에서 날짜,시간을 GMT시간으로 알아야하는데 이부분은 github를 참고하여 가져옴.
  3.2 getVector_changedFD() 함수는 인자를 적절히 넣어주면, 해당 fd_set에서 변화를 감지한 fd 값이 무엇인지 벡터로 반환해줌
4. keep-alive 기능을 없앰. runSend()함수가 호출되면, 이 함수에서 closeConnection()을 실행하게하여, 메세지를 보내게되면 무조껀 접속을 끊도록 함. (Keep-alive으로써 소켓의 연결을 끊지 않으면서, 상대방한테 메세지의 끝을 알려주는 것이 불가능하다고 판단함...) 
Feat: status_code 에러가 발생했을 때, 처리하는 방식을 모방해봄

1. runRecvAndSolve() 함수에서 에러 int status_code 가 발생했을 때, 어떻게 동작해야하는지 throw 404를 가정하고 진행해보았음.
2. <string>에 있는 모든 함수를 허용함에 따라서, ft::itoa를 std::to_string 으로 모두 수정함. (stoi는 c++11이라서, ft::ft_atoi를 써야함

