### PR TITLE
Feat: 맨 뒤에 슬래쉬에 따라서 폴더인지 파일인지 그리고 리디렉션

### DIFF
--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -156,20 +156,20 @@ void								Request::ParseURI(std::string& uri)
 	}
 	// filename parsing
 	found = uri.find_last_of("/");
-	if (found != uri.length() - 1)
+	if (found != uri.length() - 1) //  localhost/eee/fff
 	{
+		mURItype = Request::FILE;
+		mFileName = uri.substr(found + 1);
 		std::size_t	dot = uri.substr(found + 1).rfind(".");
 		if (dot != std::string::npos)
 		{
-			mURItype = Request::FILE;
-			mFileName = uri.substr(found + 1);
 			std::string	extension = mFileName.substr(dot);
 			if (extension.compare(".bla") == 0/* || extension.compare(".php") == 0*/)
 			{
 				mURItype = Request::CGI_PROGRAM;
 			}
-			uri.resize(found);
 		}
+		uri.resize(found);
 	}
 	// directory parsing
 	mDirectory = uri;

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -156,6 +156,10 @@ void								Request::ParseURI(std::string& uri)
 	}
 	// filename parsing
 	found = uri.find_last_of("/");
+	if (found == std::string::npos)
+	{
+		throw 400;
+	}
 	if (found != uri.length() - 1) //  localhost/eee/fff
 	{
 		mURItype = Request::FILE;

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -100,7 +100,7 @@ void		Response::make_m_firstline()
 	this->m_firstline += "HTTP/1.1 ";
 	this->m_firstline += ft::itos(m_status_code);
 	this->m_firstline += " ";
-	this->m_firstline += this->m_status_description;
+	this->m_firstline += m_status_map[m_status_code];
 }
 
 void		Response::set_m_headers(std::string header_key, std::string header_value)

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -310,6 +310,13 @@ void			Server::create_Response_statuscode(Connection &connection, int status_cod
 	response->set_m_headers("Content-Type", "text/html");
 	response->set_m_headers("Content-Length", ft::itos(errorpage_body.size()));
 	response->set_m_body(errorpage_body);
+	if (status_code == 301)
+	{
+		std::string url;
+		// url += "http://" + this->mhost + connection.get_m_request()->GetDirectory() + "/" + connection.get_m_request()->GetFileName() + "/";
+		// NOTE 상대 경로만 적어주어도 됨
+		response->set_m_headers("Location", connection.get_m_request()->GetDirectory() + "/" + connection.get_m_request()->GetFileName() + "/");
+	}
 }
 
 void			Server::create_Response_0(Connection &connection, std::string uri_plus_file)
@@ -407,17 +414,17 @@ void			Server::solveRequest(Connection& connection, Request& request)
 		connection.SetStatus(Connection::SEND_READY);
 
 	}
-	else if (request.GetURItype() == Request::DIRECTORY || (request.GetURItype() == Request::DIRECTORY && request.GetMethod() == "POST"))
+	else if (request.GetURItype() == Request::DIRECTORY)
 	{
 		if (locationPath->mclient_max_body_size < request.getBody().length() && locationPath->mclient_max_body_size != 0)
 			throw 413;
-		if (ft::access(absolute_path + root + relative_path) == true) // NOTE 있는 폴더 경로에 접근 했을 때, index,html or autoindex
+		if (ft::access(absolute_path + root + relative_path, 0) == 0) // NOTE 있는 폴더 경로에 접근 했을 때, index,html or autoindex
 		{
 			for (std::size_t i = 0; i < locationPath->mindex_pages.size(); i++)
 			{
 				std::string uri_indexhtml(absolute_path + root + request.GetDirectory());
 				uri_indexhtml += "/" + locationPath->mindex_pages[i].getPath();
-				if (ft::isFilePath(uri_indexhtml) == true && ft::access(uri_indexhtml) == true)
+				if (ft::isFilePath(uri_indexhtml) == true && ft::access(uri_indexhtml, 0) == 0)
 				{
 					create_Response_200(connection, uri_indexhtml, INDEX_HTML);
 					connection.SetStatus(Connection::SEND_READY);
@@ -439,70 +446,78 @@ void			Server::solveRequest(Connection& connection, Request& request)
 				throw 404;
 			}
 		}
-		else // NOTE 없는 폴더 경로에 접근 했을 때, error.html 보여주기
+		else // NOTE 없는 "폴더경로"로 접근 했을 때, 404 page. 파일이건 폴더이건 신경쓰지 않음
 		{
-			std::string uri_errorhtml(target_uri);
-			uri_errorhtml += locationPath->merror_page.getPath();
-			// uri_errorhtml.clear();
-			// uri_errorhtml = "/Users/yunslee/webserv_200/flabc/error.html";
-			create_Response_0(connection, uri_errorhtml);
-			connection.SetStatus(Connection::SEND_READY);
-			return ;
+			throw 404;
 		}
 	}
 	else if (request.GetURItype() == Request::FILE || request.GetURItype() == Request::CGI_PROGRAM)
 	{
-		if (request.GetMethod().compare("GET") == 0)
+		if (locationPath->mclient_max_body_size < request.getBody().length() && locationPath->mclient_max_body_size != 0)
+			throw 413;
+		errno = 0;
+		if (ft::access(absolute_path + root + relative_path, 0) == 0)
 		{
-			executeGet(connection, target_uri);
-			if (request.GetURItype() == Request::FILE)
+			if (ft::isDirPath(absolute_path + root + relative_path) == true && ft::isFilePath(absolute_path + root + relative_path) == false)
+			{
+				throw 301;
+			}
+			if (request.GetMethod().compare("GET") == 0)
+			{
+				executeGet(connection, target_uri);
+				if (request.GetURItype() == Request::FILE)
+					connection.SetStatus(Connection::SEND_READY);
+				else
+					connection.SetStatus(Connection::CGI_READY);
+			}
+			else if (request.GetMethod().compare("HEAD") == 0)
+			{
+				executeHead(connection, target_uri);
+				if (request.GetURItype() == Request::FILE)
+					connection.SetStatus(Connection::SEND_READY);
+				else
+					connection.SetStatus(Connection::CGI_READY);
+			}
+			else if (request.GetMethod().compare("POST") == 0)
+			{
+				if (locationPath->mclient_max_body_size < request.getBody().length() && locationPath->mclient_max_body_size != 0)
+					throw 413;
+				executePost(connection, request);
+				if (request.GetURItype() == Request::FILE)
+					connection.SetStatus(Connection::SEND_READY);
+				else
+					connection.SetStatus(Connection::CGI_READY);
+			}
+			else if (request.GetMethod().compare("DELETE") == 0)
+			{
+				executeDelete(connection, request, target_uri);
 				connection.SetStatus(Connection::SEND_READY);
-			else
-				connection.SetStatus(Connection::CGI_READY);
-		}
-		else if (request.GetMethod().compare("HEAD") == 0)
-		{
-			executeHead(connection, target_uri);
-			if (request.GetURItype() == Request::FILE)
+			}
+			else if (request.GetMethod().compare("OPTIONS") == 0)
+			{
+				executeOptions(connection, target_uri, config_it);
 				connection.SetStatus(Connection::SEND_READY);
+			}
+			// else if (request.GetMethod().compare("TRACE") == 0)
+			// {
+			// 	// executeOptions(connection, request);
+			// 	connection.SetStatus(Connection::SEND_READY);
+			// }
 			else
-				connection.SetStatus(Connection::CGI_READY);
+			{
+				throw 405; // NOTE Method NOTE Allowed
+			}
 		}
-		else if (request.GetMethod().compare("POST") == 0)
-		{
-			if (locationPath->mclient_max_body_size < request.getBody().length() && locationPath->mclient_max_body_size != 0)
-				throw 413;
-			executePost(connection, request);
-			if (request.GetURItype() == Request::FILE)
-				connection.SetStatus(Connection::SEND_READY);
-			else
-				connection.SetStatus(Connection::CGI_READY);
-		}
-		else if (request.GetMethod().compare("DELETE") == 0)
-		{
-			executeDelete(connection, request, target_uri);
-			connection.SetStatus(Connection::SEND_READY);
-		}
-		else if (request.GetMethod().compare("OPTIONS") == 0)
-		{
-			executeOptions(connection, target_uri, config_it);
-			connection.SetStatus(Connection::SEND_READY);
-		}
-		// else if (request.GetMethod().compare("TRACE") == 0)
-		// {
-		// 	// executeOptions(connection, request);
-		// 	connection.SetStatus(Connection::SEND_READY);
-		// }
 		else
 		{
-			throw 405; // NOTE Method NOTE Allowed
+			if (errno == 2)
+				throw 404;
 		}
 	}
 	else
 	{
 		throw 0;
 	}
-
 }
 
 const char* Server::IOError::what() const throw(){ return ("I/O error occurred."); }

--- a/srcs/Server_execute*.cpp
+++ b/srcs/Server_execute*.cpp
@@ -19,7 +19,7 @@ void		Server::executeAutoindex(Connection& connection, std::string uri_copy)
 
 void		Server::executeGet(Connection& connection, std::string target_uri)
 {
-	if (ft::access(target_uri) == false)
+	if (ft::access(target_uri, 0) == -1)
 	{
 		throw 404;
 	}

--- a/srcs/Utils/utils.cpp
+++ b/srcs/Utils/utils.cpp
@@ -104,54 +104,6 @@ std::string ft::itos(int n)
 	return (temp_str);
 }
 
-
-
-/**
- * isFilePath : path가 file path인지 체크하는 함수
- * @param  {std::string} path : 경로
- * @return {bool}             : 1 : 파일 경로, 0 : 파일 경로 x
- */
-bool ft::isFilePath(const std::string &path)
-{
-	struct stat info;
-
-	if (stat(path.c_str(), &info) == 0)
-	{
-		if (S_ISREG(info.st_mode))
-			return 1;
-		else
-			return 0;
-	}
-	else
-		return 0;
-}
-
-/**
- * isDirPath : path가 directory path인지 체크하는 함수
- * @param  {std::string} path : 경로
- * @return {bool}             : 1 : 폴더 경로, 0 : 폴더 경로 x
- */
-bool ft::isDirPath(const std::string &path)
-{
-	struct stat info;
-
-	if (stat(path.c_str(), &info) == 0)
-	{
-		if (S_ISDIR(info.st_mode))
-			return 1;
-		else
-			return 0;
-	}
-	else
-		return 0;
-}
-/**
- * getStatusStr : 상태 코드에 따른 메세지 문자열을 구해주는 함수
- * @param  {uint16_t} code : 상태 코드
- * @return {std::string}   : 상태 코드에 따른 상태 메세지 문자열
- */
-
-
 u_int32_t ft::ft_htonl(u_int32_t addr)
 {
 	int num = 1;
@@ -300,29 +252,6 @@ std::string ft::getCurrentTime()
 	return (getHTTPTimeFormat(time.tv_sec));
 }
 
-bool ft::access(std::string absolute_path)
-{
-	if (ft::isDirPath(absolute_path) == true)
-	{
-		DIR *dir;
-		dir = opendir(absolute_path.c_str());
-		closedir(dir); // NOTE 추가함
-		if (dir == NULL)
-			return (false);
-		else
-			return (true);
-	}
-	else if (ft::isFilePath(absolute_path) == true)
-	{
-		int fd = open(absolute_path.c_str(), 0);
-		close(fd);
-		if (fd == -1)
-			return (false);
-		else
-			return (true);
-	}
-	return (false);
-}
 
 unsigned long	ft::stohex(const std::string &str)
 {
@@ -397,4 +326,59 @@ std::string		ft::inet_ntos(struct in_addr in)
     in.s_addr >>= 8;
 	ret += itos((in.s_addr & mask));
 	return (ret);
+}
+
+bool ft::isFilePath(const std::string &path)
+{
+	struct stat info;
+
+	if (stat(path.c_str(), &info) == 0)
+	{
+		if (S_ISREG(info.st_mode))
+			return 1;
+		else
+			return 0;
+	}
+	else
+		return 0;
+}
+
+bool ft::isDirPath(const std::string &path)
+{
+	struct stat info;
+
+	if (stat(path.c_str(), &info) == 0)
+	{
+		if (S_ISDIR(info.st_mode))
+			return 1;
+		else
+			return 0;
+	}
+	else
+		return 0;
+}
+
+int ft::access(std::string absolute_path, int temp)
+{
+	if (ft::isDirPath(absolute_path) == true)
+	{
+		DIR *dir;
+		dir = opendir(absolute_path.c_str());
+		closedir(dir); // NOTE 추가함
+		if (dir == NULL)
+			return (-1);
+		else
+			return (0);
+	}
+	else if (ft::isFilePath(absolute_path) == true)
+	{
+		int fd = open(absolute_path.c_str(), 0);
+		close(fd);
+		if (fd == -1)
+			return (-1);
+		else
+			return (0);
+	}
+	return (-1);
+	(void)temp;
 }

--- a/srcs/Utils/utils.hpp
+++ b/srcs/Utils/utils.hpp
@@ -31,7 +31,7 @@ namespace ft
 	std::string		itos(int n);
 	// int				atoi(const char *str); // NOTE std::atoi으로 대체가능 <iostream>
 
-	bool access(std::string absolute_path);
+	int	 access(std::string absolute_path, int temp);
 	bool isFilePath(const std::string &path);
 	bool isDirPath(const std::string &path);
 	std::string makeAutoindexHTML(std::string root);

--- a/test.config
+++ b/test.config
@@ -9,11 +9,11 @@ server
 	location /put_test
 	{
 		root YoupiBanane/directory
-		method PUT
+		method PUT GET
 	}
 	location /post_body
 	{
-		method POST
+		method POST GET
 		client_max_body_size 100
 		root YoupiBanane/directory
 		autoindex on


### PR DESCRIPTION
1. ft::access() 함수를 실제 access()함수와 비슷하게 만들었음.
2. URL에서 맨뒤에 `/`가 있는지 없는지에 따라서, 파일인지 폴더인지 판단하도록 함.
3. 폴더 경로인 경우에는 무조껀 폴더 경로만 생각하지만, 파일 경로인 경우(맨 마지막에 `/`가 없는 경우)에는 파일이 존재하는지보고 없다면 폴더로 접근하는데 이때 접근하는 방법이 리디렉션을 이용한다. 뒤에 `/`를 붙여서 Location 헤더에 넣어주면, GET 메소드로 해당 URL로 request 한다
4. 테스터에서도 이러한 리디렉션을 유도하였고 실제로 테스터를 다시 돌려보니 잘 동작함

- 관련자료
  <img width="1375" alt="access함수" src="https://user-images.githubusercontent.com/56223639/120103564-29c01080-c18b-11eb-94aa-4a04559b6205.png">

## ISSUE 
Resolves: #70 #61 #51 