### PR TITLE
Fix: 411 상태 코드 처리 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CC		=	clang++
 #CFLAGS	=	-Wall -Wextra -Werror -std=c++98 -g3 -fsanitize=address
 # CFLAGS	=	-Wall -Wextra -Werror -std=c++98 -g3
 # CFLAGS	=	-std=c++98 -g3 -fsanitize=address
-CFLAGS	=	-std=c++98 -Wall -Wextra -Werror
+CFLAGS	=	-std=c++98 -Wall -Wextra -Werror -g3
 
 
 RM		=	-rm -rf

--- a/ft_tester/statusCodeTester.cpp
+++ b/ft_tester/statusCodeTester.cpp
@@ -3,6 +3,75 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+void	test411(const struct sockaddr_in& sockAddr)
+{
+	{
+		int	clientSocket = socket(AF_INET, SOCK_STREAM, 0);
+		if (connect(clientSocket, (struct sockaddr*)&sockAddr, sizeof(sockAddr)) < 0)
+		{
+			throw std::exception();
+		}
+		std::cout << "TEST 411 STATUS CODE" << std::endl;
+		std::cout << "When existing content-length" << std::endl;
+		std::cout << "--------------------------" << std::endl;
+		std::string	message;
+		std::string	method("PUT");
+		std::string	uri("/put_test/temp");
+		std::string	version("HTTP/1.1");
+		message += method + " " + uri + " " + version + "\r\n";
+		message += "content-length: 10\r\n";
+		message += "\r\n";
+		message += "kkkkkkkkkk";
+		std::cout << message << std::endl;
+		std::cout << "--------------------------" << std::endl;
+		write(clientSocket, message.c_str(), message.length());
+
+		char	buf[13];
+		ssize_t	ret = read(clientSocket, buf, 13);
+		std::string	returnStatusCode = std::string(buf).substr(9, 3);
+		std::cout << "expected 200" << " returned " << returnStatusCode << std::endl;
+		std::cout << "--------------------------" << std::endl;
+		if (returnStatusCode.compare("200") != 0)
+		{
+			throw std::exception();
+		}
+		close(clientSocket);
+	}
+	std::cout << std::endl;
+	{
+		int	clientSocket = socket(AF_INET, SOCK_STREAM, 0);
+		if (connect(clientSocket, (struct sockaddr*)&sockAddr, sizeof(sockAddr)) < 0)
+		{
+			throw std::exception();
+		}
+		std::cout << "TEST 411 STATUS CODE" << std::endl;
+		std::cout << "When not existing content-length" << std::endl;
+		std::cout << "--------------------------" << std::endl;
+		std::string	message;
+		std::string	method("PUT");
+		std::string	uri("/put_test/414test2");
+		std::string	version("HTTP/1.1");
+		message += method + " " + uri + " " + version + "\r\n";
+		message += "\r\n";
+		message += "kkkkkkkkkk";
+		std::cout << message << std::endl;
+		std::cout << "--------------------------" << std::endl;
+		write(clientSocket, message.c_str(), message.length());
+
+		char	buf[13];
+		ssize_t	ret = read(clientSocket, buf, 13);
+		std::string	returnStatusCode = std::string(buf).substr(9, 3);
+		std::cout << "expected 505" << " returned " << returnStatusCode << std::endl;
+		std::cout << "--------------------------" << std::endl;
+		if (returnStatusCode.compare("505") != 0)
+		{
+			throw std::exception();
+		}
+		close(clientSocket);
+	}
+	std::cout << std::endl;
+}
+
 void	test505(const struct sockaddr_in& sockAddr)
 {
 	{
@@ -165,7 +234,7 @@ int	main(int argc, char* argv[])
 		//test400();
 		test414(sockAddr);
 		test505(sockAddr);
-		//test411();
+		test411(sockAddr);
 		//test413();
 		//test301();
 		//test404();

--- a/ft_tester/statusCodeTester.cpp
+++ b/ft_tester/statusCodeTester.cpp
@@ -16,7 +16,7 @@ void	test411(const struct sockaddr_in& sockAddr)
 		std::cout << "--------------------------" << std::endl;
 		std::string	message;
 		std::string	method("PUT");
-		std::string	uri("/put_test/temp");
+		std::string	uri("/put_test/temp2");
 		std::string	version("HTTP/1.1");
 		message += method + " " + uri + " " + version + "\r\n";
 		message += "content-length: 10\r\n";
@@ -29,9 +29,9 @@ void	test411(const struct sockaddr_in& sockAddr)
 		char	buf[13];
 		ssize_t	ret = read(clientSocket, buf, 13);
 		std::string	returnStatusCode = std::string(buf).substr(9, 3);
-		std::cout << "expected 200" << " returned " << returnStatusCode << std::endl;
+		std::cout << "expected 200, 201" << " returned " << returnStatusCode << std::endl;
 		std::cout << "--------------------------" << std::endl;
-		if (returnStatusCode.compare("200") != 0)
+		if (!(returnStatusCode.compare("200") == 0 || returnStatusCode.compare("201") == 0 || returnStatusCode.compare("204") == 0))
 		{
 			throw std::exception();
 		}
@@ -52,6 +52,7 @@ void	test411(const struct sockaddr_in& sockAddr)
 		std::string	uri("/put_test/414test2");
 		std::string	version("HTTP/1.1");
 		message += method + " " + uri + " " + version + "\r\n";
+		message += "MyHeader: kkk\r\n";
 		message += "\r\n";
 		message += "kkkkkkkkkk";
 		std::cout << message << std::endl;
@@ -61,9 +62,9 @@ void	test411(const struct sockaddr_in& sockAddr)
 		char	buf[13];
 		ssize_t	ret = read(clientSocket, buf, 13);
 		std::string	returnStatusCode = std::string(buf).substr(9, 3);
-		std::cout << "expected 505" << " returned " << returnStatusCode << std::endl;
+		std::cout << "expected 411" << " returned " << returnStatusCode << std::endl;
 		std::cout << "--------------------------" << std::endl;
-		if (returnStatusCode.compare("505") != 0)
+		if (returnStatusCode.compare("411") != 0)
 		{
 			throw std::exception();
 		}
@@ -232,8 +233,8 @@ int	main(int argc, char* argv[])
 		//test408();
 		//test503();
 		//test400();
-		test414(sockAddr);
-		test505(sockAddr);
+		//test414(sockAddr);
+		//test505(sockAddr);
 		test411(sockAddr);
 		//test413();
 		//test301();

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -271,8 +271,12 @@ bool			Server::parseBody(Connection& connection)
 	}
 	else
 	{
-		// NOTE contents-length parsing
+		// NOTE content-length parsing
 		std::map<std::string, std::string>::iterator	it = request->GetHeaders().find("content-length");
+		if (it == request->GetHeaders().end())
+		{
+			throw 411;
+		}
 		int												contentLength = std::atoi(it->second.c_str());
 		int												bodyLength = request->get_m_origin().length() - request->GetSeek();
 		// std::cout << contentLength << " " << bodyLength << std::endl;


### PR DESCRIPTION
content-length가 없는 경우 모두 411로 처리해주려했더니, tester에서
chunked일 경우 content-length를 보내지 않느 경우가 많아 chunked가 아닐
경우에만 content-length가 없으면 411로 처리하도록 하였음.

> ⚠️ 이슈 없이 Pull Request 금지  
> 아래 항목은 필수이지만, 필요없다고 생각하는 부분은 삭제하고 필요한 부분은 자유롭게 추가 가능

## **WHAT?**

## **WHY?**

## **TESTING**

## ISSUE and REFERENCE
