### PR TITLE
Fix: 408 상태코드 처리 + 테스터 추가

### DIFF
--- a/ft_tester/statusCodeTester.cpp
+++ b/ft_tester/statusCodeTester.cpp
@@ -3,6 +3,30 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+void	test408(const struct sockaddr_in& sockAddr)
+{
+	{
+		int	clientSocket = socket(AF_INET, SOCK_STREAM, 0);
+		if (connect(clientSocket, (struct sockaddr*)&sockAddr, sizeof(sockAddr)) < 0)
+		{
+			throw std::exception();
+		}
+		std::cout << "TEST 408 STATUS CODE" << std::endl;
+		std::cout << "We will do nothing!!" << std::endl;
+		std::cout << "--------------------------" << std::endl;
+		char	buf[13];
+		ssize_t	ret = read(clientSocket, buf, 13);
+		std::string	returnStatusCode = std::string(buf).substr(9, 3);
+		std::cout << "expected 408" << " returned " << returnStatusCode << std::endl;
+		std::cout << "--------------------------" << std::endl;
+		if (returnStatusCode.compare("408") != 0)
+		{
+			throw std::exception();
+		}
+		close(clientSocket);
+	}
+}
+
 void	test405(const struct sockaddr_in& sockAddr)
 {
 	{
@@ -406,7 +430,6 @@ int	main(int argc, char* argv[])
 		sockAddr.sin_family = AF_INET;
 		sockAddr.sin_port = htons(std::stoi(port));
 		sockAddr.sin_addr.s_addr = inet_addr(host.c_str());
-		//test408();
 		//test503();
 		//test400();
 		//test414(sockAddr);
@@ -414,7 +437,7 @@ int	main(int argc, char* argv[])
 		//test411(sockAddr);
 		//test413(sockAddr);
 		//test301(sockAddr);
-		test405(sockAddr);
+		//test405(sockAddr);
 		//test404();
 		//test410();
 		//test401();
@@ -425,6 +448,7 @@ int	main(int argc, char* argv[])
 		//test201();
 		//test205();
 		//test204();
+		test408(sockAddr);
 	}
 	catch(const std::exception& e)
 	{

--- a/ft_tester/statusCodeTester.cpp
+++ b/ft_tester/statusCodeTester.cpp
@@ -14,7 +14,7 @@ void	test408(const struct sockaddr_in& sockAddr)
 		std::cout << "TEST 408 STATUS CODE" << std::endl;
 		std::cout << "We will do nothing!!" << std::endl;
 		std::cout << "--------------------------" << std::endl;
-		char	buf[13];
+		char	buf[14] = {0,};
 		ssize_t	ret = read(clientSocket, buf, 13);
 		std::string	returnStatusCode = std::string(buf).substr(9, 3);
 		std::cout << "expected 408" << " returned " << returnStatusCode << std::endl;

--- a/ft_tester/statusCodeTester.cpp
+++ b/ft_tester/statusCodeTester.cpp
@@ -430,29 +430,33 @@ int	main(int argc, char* argv[])
 		sockAddr.sin_family = AF_INET;
 		sockAddr.sin_port = htons(std::stoi(port));
 		sockAddr.sin_addr.s_addr = inet_addr(host.c_str());
-		//test503();
-		//test400();
-		//test414(sockAddr);
-		//test505(sockAddr);
-		//test411(sockAddr);
-		//test413(sockAddr);
-		//test301(sockAddr);
-		//test405(sockAddr);
+		test414(sockAddr);
+		test505(sockAddr);
+		test411(sockAddr);
+		test413(sockAddr);
+		test301(sockAddr);
 		test405(sockAddr);
 		test301(sockAddr);
 		test413(sockAddr);
-		//test301();
-		//test404();
-		//test410();
-		//test401();
-		//test403();
-		//test500();
-		//test504();
-		//test200();
-		//test201();
-		//test205();
-		//test204();
 		test408(sockAddr);
+
+		// TODO 구현 될 것
+		// test403(); Auth
+		// test401(); UNAuth
+
+		// NOTE 구현되지 않은 것
+		// test410(); GONE
+
+		// NOTE 구현되었으나 테스터에서 보여주지 않는 것
+		// test205(); Reset content
+		// test204(); NO content
+		// test503();
+		// test400();
+		// test404();
+		// test201();
+		// test200();
+		// test500();
+		// test504();
 	}
 	catch(const std::exception& e)
 	{

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -314,7 +314,11 @@ void			Server::create_Response_statuscode(Connection &connection, int status_cod
 	Response *response = connection.get_m_response();
 	response->set_m_headers("Server", "YKK_webserv");
 	response->set_m_headers("Date", ft::getCurrentTime());
-	std::string errorpage_body = Response::makeStatusPage(status_code, connection.get_m_request()->GetMethod());
+	std::string errorpage_body;
+	if (connection.get_m_request() != NULL)
+		errorpage_body = Response::makeStatusPage(status_code, connection.get_m_request()->GetMethod());
+	else
+		errorpage_body = Response::makeStatusPage(status_code, "");
 	response->set_m_headers("Content-Type", "text/html");
 	response->set_m_headers("Content-Length", ft::itos(errorpage_body.size()));
 	response->set_m_body(errorpage_body);
@@ -349,31 +353,6 @@ void			Server::create_Response_0(Connection &connection, std::string uri_plus_fi
 	if (fd > 2)
 		close(fd);
 	return ;
-}
-
-void			Server::create_Response_408(Connection &connection)
-{
-	connection.set_m_response(new Response(&connection, 408));
-	Response*	response = connection.get_m_response();
-	response->set_m_headers("Server", "webserv");
-	response->set_m_headers("Date", ft::getCurrentTime().c_str());
-	response->set_m_headers("Connection", "close");
-	response->set_m_headers("Content-Type", "text/html");
-	response->set_m_headers("Content-Language", "en-US");
-
-	std::string body;
-	int fd = -1;
-	if (body.size() == 0)
-	{
-		fd = open("./error.html", O_RDONLY);
-		body = ft::getBody_from_fd(fd);
-	}
-	response->set_m_body(body);
-	response->set_m_headers("Content-Length", ft::itos(response->get_m_body().length()));
-	if (fd > 2)
-	{
-		close(fd);
-	}
 }
 
 void			Server::create_Response_200(Connection &connection, std::string uri_plus_file, TYPE_HTML type)

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -347,6 +347,31 @@ void			Server::create_Response_0(Connection &connection, std::string uri_plus_fi
 	return ;
 }
 
+void			Server::create_Response_408(Connection &connection)
+{
+	connection.set_m_response(new Response(&connection, 408));
+	Response*	response = connection.get_m_response();
+	response->set_m_headers("Server", "webserv");
+	response->set_m_headers("Date", ft::getCurrentTime().c_str());
+	response->set_m_headers("Connection", "close");
+	response->set_m_headers("Content-Type", "text/html");
+	response->set_m_headers("Content-Language", "en-US");
+
+	std::string body;
+	int fd = -1;
+	if (body.size() == 0)
+	{
+		fd = open("./error.html", O_RDONLY);
+		body = ft::getBody_from_fd(fd);
+	}
+	response->set_m_body(body);
+	response->set_m_headers("Content-Length", ft::itos(response->get_m_body().length()));
+	if (fd > 2)
+	{
+		close(fd);
+	}
+}
+
 void			Server::create_Response_200(Connection &connection, std::string uri_plus_file, TYPE_HTML type)
 {
 	connection.set_m_response(new Response(&connection, 200));

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -114,6 +114,7 @@ public:
 	void						create_Response_statuscode(Connection& connection, int status_code);
 	void						create_Response_0(Connection &connection, std::string uri_plus_file);
 	void						create_Response_200(Connection &connection, std::string uri_plus_file, TYPE_HTML type);
+	void						create_Response_408(Connection &connection);
 
 	const int&					get_m_fd(void) const;
 

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -114,7 +114,6 @@ public:
 	void						create_Response_statuscode(Connection& connection, int status_code);
 	void						create_Response_0(Connection &connection, std::string uri_plus_file);
 	void						create_Response_200(Connection &connection, std::string uri_plus_file, TYPE_HTML type);
-	void						create_Response_408(Connection &connection);
 
 	const int&					get_m_fd(void) const;
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -60,7 +60,7 @@ void		ServerManager::RunServers(void)
 			{
 				closeOldConnection(it);
 			}
-			std::cout << "timeout\n";
+			//std::cout << "timeout\n";
 		}
 		else if (cnt > 0)
 		{
@@ -68,7 +68,6 @@ void		ServerManager::RunServers(void)
 			// read_set = ft::getVector_changedFD(&mReadCopyFds, mMaxFd + 1);
 			// std::vector<int> write_set;
 			// write_set = ft::getVector_changedFD(&mWriteCopyFds, mMaxFd + 1);
-		}
 		std::cout << "select : " << cnt << endl;
 		std::cout << "-------------------------------" << std::endl;
 
@@ -82,6 +81,7 @@ void		ServerManager::RunServers(void)
 		}
 		// updateMaxFd();
 		// cout << "-------------------------------" << endl;
+		}
 	}
 }
 
@@ -335,7 +335,11 @@ void	ServerManager::closeOldConnection(std::vector<Server>::iterator server_it)
 		}
 		if (it2->second.isKeepConnection() == false && (FD_ISSET(fd, &this->mReadCopyFds) == 0))
 		{
-			std::cout << "closeOldconnection: " << fd << std::endl;
+			//std::cout << "closeOldconnection: " << fd << std::endl;
+			server_it->create_Response_408(it2->second);
+			it2->second.get_m_response()->set_m_response(it2->second.get_m_response()->makeResponse());
+			// NOTE 보내줘도 그만 안보내줘도 그만이라 에러처리 별도로 필요없을 것같음 select당 1번이 맞는게 select 0 리턴인 턴에서 작동함
+			write(it2->first, it2->second.get_m_response()->get_m_response().c_str(), it2->second.get_m_response()->get_m_response().length());
 			server_it->closeConnection(it2->second.get_m_fd());
 			return ;
 		}


### PR DESCRIPTION
408 상태코드 처리하는 부분이랑 테스트할 수 있는 부분 추가하였음

아래 것들은 수정되는 부분이 거의없는데 이번 PR은 아주 약간 수정되는 부분이 있음

그리고 응답 보내는 부분이라서 내가 잘 못 작성햇을 수도 있어서 한번 검토 요망!

검토할 때 주의할 점은 select가 0반환하는 경우라서 request랑 response둘다 안만들어졌다는 가정하에 작업하는 것이 좋을것같음

테스트 케이스는 그냥 커넥션만 연결해놓고 아무것도 안하고 기다리는 것으로 추가함

추가적으로 `telnet localhost:8000` 요렇게 커넥션만 연결해놓고 타임아웃 기다리는 방법으로도 테스트 가능