### PR TITLE
Fix: Executeoptions

### DIFF
--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -179,11 +179,10 @@ void								Request::ParseURI(std::string& uri)
 	mDirectory = uri;
 	// * 일때 파일로 처리
 	if (mMethod.compare("OPTIONS") == 0 &&
-		mDirectory.rfind("*") == mDirectory.length() - 1)
+		(mFileName.rfind("*") != std::string::npos && mFileName.length() == 1))
 	{
-		mFileName = mDirectory;
-		mDirectory.clear();
-		mURItype = Request::FILE;
+		mFileName.clear();
+		mURItype = Request::DIRECTORY;
 	}
 	if (mMethod.compare("PUT") == 0) // STUB POST메소드도 추가해야할수도
 	{

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -442,7 +442,7 @@ void			Server::solveRequest(Connection& connection, Request& request)
 		{
 			if (request.GetMethod().compare("OPTIONS") == 0)
 			{
-				executeOptions(connection, targetUri, configIterator);
+				executeOptions(connection, configIterator);
 				connection.SetStatus(Connection::SEND_READY);
 				return ;
 			}
@@ -557,7 +557,7 @@ void			Server::solveRequest(Connection& connection, Request& request)
 				}
 				else if (request.GetMethod().compare("OPTIONS") == 0)
 				{
-					executeOptions(connection, targetUri, configIterator);
+					executeOptions(connection, configIterator);
 					connection.SetStatus(Connection::SEND_READY);
 				}
 				// else if (request.GetMethod().compare("TRACE") == 0)

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -411,7 +411,6 @@ void			Server::solveRequest(Connection& connection, Request& request)
 	if (isValidMethod(request, configIterator) == false)
 	{
 		throw 405;
-		return ;
 	}
 	if (hasAuthModule(configIterator)) // STUB 	일단 항상 참이게 구현
 	{
@@ -439,8 +438,14 @@ void			Server::solveRequest(Connection& connection, Request& request)
 	{
 		if (locationPath->mClientMaxBodySize < request.GetBody().length() && locationPath->mClientMaxBodySize != 0)
 			throw 413;
-		if (ft::access(absolute_path + root + relative_path, 0) == 0) // NOTE 있는 폴더 경로에 접근 했을 때, index,html or autoindex
+		if (ft::access(targetUri, 0) == 0) // NOTE 있는 폴더 경로에 접근 했을 때, index,html or autoindex
 		{
+			if (request.GetMethod().compare("OPTIONS") == 0)
+			{
+				executeOptions(connection, targetUri, configIterator);
+				connection.SetStatus(Connection::SEND_READY);
+				return ;
+			}
 			for (std::size_t i = 0; i < locationPath->mIndexPages.size(); i++)
 			{
 				std::string uri_indexhtml(absolute_path + root + request.GetDirectory());
@@ -509,9 +514,9 @@ void			Server::solveRequest(Connection& connection, Request& request)
 		else
 		{
 			errno = 0;
-			if (ft::access(absolute_path + root + relative_path, 0) == 0)
+			if (ft::access(targetUri, 0) == 0)
 			{
-				if (ft::isDirPath(absolute_path + root + relative_path) == true && ft::isFilePath(absolute_path + root + relative_path) == false)
+				if (ft::isDirPath(targetUri) == true && ft::isFilePath(targetUri) == false)
 				{
 					throw 301;
 				}

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -101,7 +101,7 @@ public:
 	void								executePost(Connection& connection, const Request& request);
 	void								executePut(Connection& connection, const Request& request, std::string targetUri);
 	void								executeDelete(Connection& connection, const Request& request, std::string targetUri);
-	void								executeOptions(Connection& connection, std::string targetUri, configIterator configIterator);
+	void								executeOptions(Connection& connection, configIterator configIterator);
 	void								aexecuteTrace(Connection& connection);
 	void								executeCGI(Connection& connection);
 	void								createResponseStatusCode(Connection& connection, int statusCode);

--- a/srcs/Server_execute*.cpp
+++ b/srcs/Server_execute*.cpp
@@ -184,7 +184,7 @@ void		Server::executeDelete(Connection& connection, const Request& request, std:
 	errno = 0; // NOTE 초기화!
 }
 
-void		Server::executeOptions(Connection& connection, std::string targetUri, configIterator configIterator)
+void		Server::executeOptions(Connection& connection, configIterator configIterator)
 {
 	connection.SetResponse(new Response(&connection, 200));
 	Response *response = connection.GetResponse();

--- a/srcs/Server_execute*.cpp
+++ b/srcs/Server_execute*.cpp
@@ -186,25 +186,18 @@ void		Server::executeDelete(Connection& connection, const Request& request, std:
 
 void		Server::executeOptions(Connection& connection, std::string targetUri, configIterator configIterator)
 {
-	int fd = open(targetUri.c_str(), O_RDONLY);
-	if (fd < 0)
-		throw 404;
-	else
+	connection.SetResponse(new Response(&connection, 200));
+	Response *response = connection.GetResponse();
+	response->setHeaders("Date", ft::getCurrentTime().c_str());
+	response->setHeaders("Server", "webserv");
+	std::string value;
+	for (size_t i = 0; i < configIterator.locationPath->mMethod.size(); i++)
 	{
-		connection.SetResponse(new Response(&connection, 200));
-		Response *response = connection.GetResponse();
-		response->setHeaders("Date", ft::getCurrentTime().c_str());
-		response->setHeaders("Server", "webserv");
-		std::string value;
-		for (size_t i = 0; i < configIterator.locationPath->mMethod.size(); i++)
-		{
-			value += configIterator.locationPath->mMethod[i];
-			if (i != configIterator.locationPath->mMethod.size() - 1)
-				value += " ";
-		}
-		response->setHeaders("Allow", value);
-		close(fd);
+		value += configIterator.locationPath->mMethod[i];
+		if (i != configIterator.locationPath->mMethod.size() - 1)
+			value += " ";
 	}
+	response->setHeaders("Allow", value);
 }
 
 void		Server::aexecuteTrace(Connection& connection)

--- a/test_options.config
+++ b/test_options.config
@@ -1,0 +1,28 @@
+server
+{
+	host 127.0.0.1
+	port 8000
+	timeout 200
+	cgi_extension .bla
+	index_pages index.html
+	location /put_test
+	{
+		root YoupiBanane/directory
+	}
+	location /post_body
+	{
+		client_max_body_size 100
+		root YoupiBanane/directory
+		autoindex on
+	}
+	location /directory
+	{
+		root YoupiBanane
+		index_pages youpi.bad_extension
+	}
+	location /html
+	{
+		auth_basic_user_file .htpasswd
+		autoindex on
+	}
+}


### PR DESCRIPTION
TDD 방식으로 문제해결 함.
test_options.config 로 서버생성후 테스트하면 됨

1. 파일경로로 접근, 특정 리소스파일 없는 경우, 404
2. 파일경로로 접근, 특정 리소스파일 있는 경우, 해당 location 블록에 allowed method
3. 폴더경로로 접근, 특정 폴더가 있는 경우, 해당 location 블록에 allowed method
4. 폴더경로로 접근, 특정 폴더가 없는 경우, 404
5. 파일경로로 접근, 폴더인 경우 어쩔 수 없이 GET redirection
6. `localhost:8000/directory/*`  특수한 경우
7. `localhost:8000/YoupiBanane/**` 특수한 경우를 꼬은 경우 404 에러

Related to: #108 
